### PR TITLE
tests: allow socket_client to run tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -362,7 +362,7 @@ fn main() -> Result<(), ()> {
                 unsafe {
                     test_suite::start_tests(cntx_ptr, test_suite::TestBackend::DoeBackend);
                 }
-            } else if cli.socket_server {
+            } else if cli.socket_server || cli.socket_client {
                 unsafe {
                     test_suite::start_tests(cntx_ptr, test_suite::TestBackend::SocketBackend);
                 }


### PR DESCRIPTION
This change allows the client to also initiate the tests suite. That is, first starting the responder as a server, then client with `tests`.