### PR TITLE
request: minimal handling for responder unsupported capability

### DIFF
--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -672,7 +672,12 @@ pub unsafe fn start_session(
     );
 
     if LibspdmReturnStatus::libspdm_status_is_error(ret) {
-        return Err(ret);
+        // Gracefully handle an unsupported capability error from a responder
+        if libspdm_status_code!(ret) == LIBSPDM_STATUS_UNSUPPORTED_CAP {
+            error!("Unsupported capability detected from responder");
+        } else {
+            return Err(ret);
+        }
     }
     Ok(session_info)
 }


### PR DESCRIPTION
Log an error if the responder returns an unsupported capability. This allows us to still setup a session and try sending a request.

For instance, if the responder is using SPDM version 1.0, using keyexhcange is not supported in versions less than 1.1. We can log an error for such a case here as it isn't critical, but still send another request (get-version) later that isn't impaceted by this missing functionality.