### PR TITLE
tock-responder:  add i2c transport and drop newlib/libtock-c dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,6 +7,3 @@
 [submodule "tock-responder/libtock-rs"]
 	path = tock-responder/libtock-rs
 	url = https://github.com/tock/libtock-rs.git
-[submodule "tock-responder/libtock-c"]
-	path = tock-responder/libtock-c
-	url = https://github.com/tock/libtock-c.git

--- a/tock-responder/Cargo.lock
+++ b/tock-responder/Cargo.lock
@@ -282,6 +282,7 @@ dependencies = [
  "libtock_ninedof",
  "libtock_platform",
  "libtock_proximity",
+ "libtock_rng",
  "libtock_runtime",
  "libtock_sound_pressure",
  "libtock_temperature",
@@ -392,6 +393,13 @@ version = "0.1.0"
 
 [[package]]
 name = "libtock_proximity"
+version = "0.1.0"
+dependencies = [
+ "libtock_platform",
+]
+
+[[package]]
+name = "libtock_rng"
 version = "0.1.0"
 dependencies = [
  "libtock_platform",

--- a/tock-responder/Cargo.toml
+++ b/tock-responder/Cargo.toml
@@ -62,3 +62,8 @@ panic = "abort"
 [workspace]
 exclude = ["libtock-rs"]
 members = ["libtock-rs/runner"]
+
+[features]
+# Enable debug printing of SPDM buffers, this will
+# significantly affect throughput speed (printing overhead).
+spdm_debug = []

--- a/tock-responder/Makefile
+++ b/tock-responder/Makefile
@@ -2,6 +2,10 @@
 # Specify Bash instead so we don't have to test against a variety of shells.
 include libtock-rs/Makefile
 
+ifdef FEATURES
+features=--features=$(FEATURES)
+endif
+
 # Creates the `make <BOARD> EXAMPLE=<EXAMPLE>` targets. Arguments:
 #  1) The name of the platform to build for.
 #  2) The target architecture the platform uses.

--- a/tock-responder/README.md
+++ b/tock-responder/README.md
@@ -8,28 +8,35 @@ RISCV=1 ./build_all.sh
 cd ../../
 ```
 
-## Build libspdm for no_std targets
 
-Building for RISC-V:
+## Building libspdm
+
+### Warnings
+
+Currently only `Release` mode for `libspdm` is supported. Building in `Debug` mode requires additional functionality (`printf` support etc...), these are currently not implemented by the tock-responder.
+
+### Build libspdm for no_std targets
+
+#### Building for RISC-V:
 
 ```shell
 pushd ../third-party/libspdm/
 
 mkdir -p build_no_std_riscv
 cd build_no_std_riscv
-cmake -DARCH=riscv32 -DTOOLCHAIN=RISCV_NONE -DTARGET=Debug -DCRYPTO=mbedtls -DDISABLE_TESTS=1 ..
+cmake -DARCH=riscv32 -DTOOLCHAIN=RISCV_NONE -DTARGET=Release -DCRYPTO=mbedtls -DDISABLE_TESTS=1 CFLAGS="-DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1" ..
 make -j8
 cd ../
 ```
 
-Building for ARM:
+#### Building for ARM:
 
 Note, that the -DMARCH option must be specified with the respective ARM target architecture. This argument is passed directly to the compiler. See `man arm-none-eabi-gcc` for all supported options.
 
-```
+```shell
 mkdir -p build_no_std_arm
 cd build_no_std_arm
-cmake -DARCH=arm -DTOOLCHAIN=ARM_GNU_BARE_METAL -DTARGET=Release -DCRYPTO=mbedtls -DDISABLE_TESTS=1 -DMARCH=<march> -DDISABLE_LTO=1 ..
+cmake -DARCH=arm -DTOOLCHAIN=ARM_GNU_BARE_METAL -DTARGET=Release -DCRYPTO=mbedtls -DDISABLE_TESTS=1 -DMARCH=armv7e-m -DDISABLE_LTO=1 CFLAGS="-DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1" ..
 make -j8
 cd ../
 

--- a/tock-responder/build.rs
+++ b/tock-responder/build.rs
@@ -25,39 +25,6 @@ fn main() {
     println!("cargo:rustc-link-arg=-lspdm_transport_pcidoe_lib");
     println!("cargo:rustc-link-arg=-lspdm_transport_mctp_lib");
 
-    // As we are linking against a C application we need to provide newlib
-    // Rust isn't currently able to do this.
-    // See https://github.com/rust-embedded/book/issues/255 for more details
-    if arch == "riscv32imac" {
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32imac/libc.a");
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32imac/libm.a");
-    } else if arch == "riscv32im" {
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32im/libc.a");
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32im/libm.a");
-    } else if arch == "riscv32imc" {
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32i/libc.a");
-        println!("cargo:rustc-link-arg=libtock-c/newlib/rv32/rv32i/libm.a");
-    } else if arch == "thumbv7em" {
-        println!("cargo:rustc-link-arg=libtock-c/newlib/cortex-m/v7-m/libc.a");
-        println!("cargo:rustc-link-arg=libtock-c/newlib/cortex-m/v7-m/libm.a");
-    } else {
-        unreachable!();
-    }
-
-    // As we are using newlib, we also need to provide implementations for
-    // the newlib stubs. libtock-c does this already, so let's use that.
-    if arch == "riscv32imac" {
-        println!("cargo:rustc-link-arg=libtock-c/libtock/build/rv32imac/libtock.a");
-    } else if arch == "riscv32imc" {
-        println!("cargo:rustc-link-arg=libtock-c/libtock/build/rv32imc/libtock.a");
-    } else if arch == "riscv32im" {
-        println!("cargo:rustc-link-arg=libtock-c/libtock/build/rv32im/libtock.a");
-    } else if arch == "riscv32i" {
-        println!("cargo:rustc-link-arg=libtock-c/libtock/build/rv32i/libtock.a");
-    } else if arch == "thumbv7em" {
-        println!("cargo:rustc-link-arg=libtock-c/libtock/build/cortex-m4/libtock.a");
-    }
-
     if arch == "riscv32imac" {
         println!("cargo:rustc-link-search=../third-party/libspdm/build_no_std_riscv/lib/");
     } else if arch == "riscv32im" {

--- a/tock-responder/src/libc_stubs.rs
+++ b/tock-responder/src/libc_stubs.rs
@@ -1,0 +1,115 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2023, Western Digital Corporation or its affiliates.
+
+//! Implementation of the libc functions required by libspdm
+
+use alloc::alloc::{alloc, dealloc, Layout};
+use core::ffi::{c_char, c_void};
+
+#[no_mangle]
+fn libspdm_get_random_number_64(rand_data: *mut u64) -> bool {
+    unsafe {
+        *rand_data = 0xDEAD_BEED_CAFE_BAAD;
+    }
+    true
+}
+
+// Based on https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/bswapsi2.c
+#[no_mangle]
+pub extern "C" fn __bswapsi2(u: u32) -> u32 {
+    (((u) & 0xff000000) >> 24)
+        | (((u) & 0x00ff0000) >> 8)
+        | (((u) & 0x0000ff00) << 8)
+        | (((u) & 0x000000ff) << 24)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn malloc(size: usize) -> *mut c_void {
+    // We want to keep track of the Layout so it can be used to dealloc() later.
+    // So allocate some extra-space for this metadata.
+    let layout_size = core::mem::size_of::<Layout>();
+    let layout = Layout::array::<u8>(size + layout_size).unwrap();
+    let ptr = alloc(layout);
+    if ptr == core::ptr::null_mut() {
+        // Use this to catch excessive heap usage, ideally return NULL
+        panic!("failed to heap allocate of size: {:} bytes", size);
+    }
+    core::ptr::write(ptr as *mut Layout, layout);
+    return ptr.offset(layout_size as isize) as *mut c_void;
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn free(ptr: *mut c_void) {
+    let layout_size = core::mem::size_of::<Layout>();
+    // The layout is stored before the data address see malloc() stub above
+    let layout_addr = ptr.offset(-(layout_size as isize));
+    // Note: Cloning just to be on the safe side here, incase of use after free.
+    //       probably not needed though.
+    let layout: Layout = core::ptr::read(layout_addr as *const Layout).clone();
+    dealloc(layout_addr as *mut u8, layout);
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn strstr(haystack: *const c_char, needle: *const c_char) -> *const c_char {
+    let mut haystack_ptr = haystack;
+
+    if unsafe { *haystack_ptr } == 0 {
+        if unsafe { *needle } == 0 {
+            return haystack_ptr;
+        } else {
+            return core::ptr::null();
+        }
+    }
+
+    // This is quadratic performance in the worst case.
+    // TODO: Optimize for speed
+    while unsafe { *haystack_ptr != 0 } {
+        let mut i = 0;
+
+        loop {
+            if unsafe { *needle.offset(i as isize) } == 0 {
+                return haystack_ptr;
+            }
+
+            if unsafe { *needle.offset(i as isize) } != *haystack_ptr.offset(i as isize) {
+                break;
+            }
+
+            i += 1;
+        }
+        haystack_ptr = unsafe { haystack_ptr.offset(1) };
+    }
+
+    core::ptr::null()
+}
+
+#[no_mangle]
+pub extern "C" fn time() {
+    todo!("libc/stub: time(): not yet implemented");
+}
+
+#[no_mangle]
+pub extern "C" fn strncmp() {
+    todo!("libc/stub: strncmp(): not yet implemented");
+}
+
+#[no_mangle]
+pub extern "C" fn gmtime() {
+    todo!("libc/stub: gmtime(): not yet implemented");
+}
+
+#[no_mangle]
+pub extern "C" fn strchr() {
+    todo!("libc/stub: strchr(): not yet implemented");
+}
+
+#[no_mangle]
+pub extern "C" fn strcmp() {
+    todo!("libc/stub: strcmp(): not yet implemented");
+}
+
+#[no_mangle]
+pub extern "C" fn rand() {
+    todo!("libc/stub: rand(): not yet implemented");
+}

--- a/tock-responder/src/main.rs
+++ b/tock-responder/src/main.rs
@@ -99,7 +99,7 @@ fn main() {
     responder::setup_capabilities(
         cntx_ptr,
         0,
-        None,
+        Some(u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_12).unwrap()),
         SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
         SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384,
     )

--- a/tock-responder/src/main.rs
+++ b/tock-responder/src/main.rs
@@ -9,7 +9,6 @@
 
 extern crate alloc;
 
-use core::ffi::{c_int, c_void};
 use core::fmt::Write;
 use critical_section::RawRestoreState;
 use embedded_alloc::Heap;
@@ -22,10 +21,11 @@ use libspdm::spdm;
 use libtock::console::Console;
 use libtock::runtime::{set_main, stack_size};
 
+mod libc_stubs;
 mod mctp;
 
 set_main! {main}
-stack_size! {0xE00}
+stack_size! {0x4000}
 
 #[global_allocator]
 static HEAP: Heap = Heap::empty();
@@ -46,33 +46,11 @@ unsafe impl critical_section::Impl for MyCriticalSection {
     unsafe fn release(_token: RawRestoreState) {}
 }
 
-// Based on https://github.com/llvm/llvm-project/blob/main/compiler-rt/lib/builtins/bswapsi2.c
-#[no_mangle]
-pub extern "C" fn __bswapsi2(u: u32) -> u32 {
-    (((u) & 0xff000000) >> 24)
-        | (((u) & 0x00ff0000) >> 8)
-        | (((u) & 0x0000ff00) << 8)
-        | (((u) & 0x000000ff) << 24)
-}
-
-extern "C" {
-    // Provided by libtock-c
-    fn gettimeasticks(tv: *mut libspdm::libspdm_rs::timeval, tzvp: *mut c_void) -> c_int;
-}
-
-#[no_mangle]
-pub unsafe extern "C" fn _gettimeofday(
-    tv: *mut libspdm::libspdm_rs::timeval,
-    tzvp: *mut c_void,
-) -> c_int {
-    gettimeasticks(tv, tzvp)
-}
-
 // Setup the heap and the global allocator.
 unsafe fn setup_heap() {
     use core::mem::MaybeUninit;
 
-    const HEAP_SIZE: usize = 1024 * 64;
+    const HEAP_SIZE: usize = 1024 * 74;
     static mut HEAP_MEM: [MaybeUninit<u8>; HEAP_SIZE] = [MaybeUninit::uninit(); HEAP_SIZE];
     unsafe { HEAP.init(HEAP_MEM.as_ptr() as usize, HEAP_SIZE) }
 }


### PR DESCRIPTION
@alistair23 I noticed on this branch the .tab size is ~100K higher than my original, I think because of the new dependencies added to the cargo.toml. 