### PR TITLE
spdm-utils: transport: usb-i2c support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,11 @@ dependencies = [
  "bindgen",
  "clap",
  "env_logger",
+ "lazy_static",
  "log",
  "memmap2",
  "once_cell",
+ "serialport",
  "sha2",
 ]
 
@@ -132,9 +134,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clang-sys"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
 dependencies = [
  "glob",
  "libc",
@@ -143,9 +145,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.11"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfaff671f6b22ca62406885ece523383b9b64022e341e53e009a62ebc47a45f2"
+checksum = "33e92c5c1a78c62968ec57dbc2440366a2d6e5a23faf829970ff1585dc6b18e2"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -153,9 +155,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.11"
+version = "4.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a216b506622bb1d316cd51328dce24e07bdff4a6128a47c7e7fad11878d5adbb"
+checksum = "f4323769dc8a61e2c39ad7dc26f6f2800524691a44d74fe3d1071a5c24db6370"
 dependencies = [
  "anstream",
  "anstyle",
@@ -172,7 +174,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.40",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -188,10 +190,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.11"
+name = "core-foundation-sys"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce420fe07aecd3e67c5f910618fe65e94158f6dcc0adf44e00d69ce2bdfe0fd0"
+checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
@@ -275,11 +283,11 @@ checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "home"
-version = "0.5.5"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -289,14 +297,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
-name = "is-terminal"
-version = "0.4.9"
+name = "io-kit-sys"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+checksum = "4769cb30e5dcf1710fc6730d3e94f78c47723a014a567de385e113c737394640"
+dependencies = [
+ "core-foundation-sys",
+ "mach2",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
 dependencies = [
  "hermit-abi",
  "rustix",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -313,18 +331,38 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.151"
+version = "0.2.152"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
+checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
 name = "libloading"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
- "winapi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "libudev"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b324152da65df7bb95acfcaab55e3097ceaab02fb19b228a9eb74d55f135e0"
+dependencies = [
+ "libc",
+ "libudev-sys",
+]
+
+[[package]]
+name = "libudev-sys"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c8469b4a23b962c1396b9b451dda50ef5b283e8dd309d69033475fa9b334324"
+dependencies = [
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]
@@ -340,10 +378,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
-name = "memchr"
-version = "2.6.4"
+name = "mach2"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+checksum = "19b955cdeb2a02b9117f121ce63aa52d08ade45de53e48fe6a38b39c10f6f709"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "memchr"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
 name = "memmap2"
@@ -359,6 +406,17 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "nom"
@@ -383,19 +441,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.70"
+name = "pkg-config"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "69d3587f8a9e599cc7ec2c00e331f71c4e69a5f9a4b8a6efd5b07466b9736f9a"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95fc56cda0b5c3325f5fbbd7ff9fda9e02bb00bb3dac51252d2f1bfa1cb8cc8c"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -449,6 +513,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "serialport"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f5a15d0be940df84846264b09b51b10b931fb2f275becb80934e3568a016828"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "libudev",
+ "mach2",
+ "nix",
+ "regex",
+ "scopeguard",
+ "unescaper",
+ "winapi",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -484,9 +573,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -495,11 +584,31 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
 ]
 
 [[package]]
@@ -507,6 +616,15 @@ name = "typenum"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
+name = "unescaper"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8f0f68e58d297ba8b22b8b5a96a87b863ba6bb46aaf51e19a4b02c5a6dd5b7f"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 default = ["std"]
 
 no_std = []
-std = ["clap", "memmap2", "once_cell", "sha2", "env_logger"]
+std = ["clap", "memmap2", "once_cell", "sha2", "env_logger", "serialport", "lazy_static"]
 
 [lib]
 name = "libspdm"
@@ -26,6 +26,8 @@ bindgen = "0.63"
 
 [dependencies]
 log = "0.4"
+serialport = { version = "4.3.0", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 clap = { version = "4.0", features = ["derive"], optional = true }
 memmap2 = { version = "0.5", optional = true}

--- a/README.md
+++ b/README.md
@@ -67,9 +67,15 @@ To build libspdm in the third-party directory
 ```shell
 cd libspdm/
 mkdir build; cd build
-cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl -DENABLE_BINARY_BUILD=1 -DCOMPILED_LIBCRYPTO_PATH=/usr/lib/ -DCOMPILED_LIBSSL_PATH=/usr/lib/ -DDISABLE_TESTS=1 ..
+cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl -DENABLE_BINARY_BUILD=1 -DCOMPILED_LIBCRYPTO_PATH=/usr/lib/ -DCOMPILED_LIBSSL_PATH=/usr/lib/ -DDISABLE_TESTS=1 CFLAGS="-DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1" ..
 make -j8
 ```
+
+Note that we build `libspdm` with chunking enabled. Chunking allows us to keep the maximum data transferred
+in a single burst down by chunking the SPDM message data into frames of digestible size(s).
+
+For example, `usb_i2c` communication with the `tock-responder` requires it, so we enable it by default.
+You can disable `LIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP` for other targets if required by omitting the `CFLAGS="-DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1` in the invocation of `cmake`.
 
 ## Build the binary
 

--- a/build.rs
+++ b/build.rs
@@ -34,6 +34,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-lspdm_crypt_lib");
     println!("cargo:rustc-link-arg=-lspdm_crypt_ext_lib");
     println!("cargo:rustc-link-arg=-lspdm_transport_pcidoe_lib");
+    println!("cargo:rustc-link-arg=-lspdm_transport_mctp_lib");
 
     // Link SPDM Test Libraries
     let builder = if cfg!(libspdm_tests) {

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -8,11 +8,11 @@ use crate::*;
 
 pub fn parse_qemu_transport_layer(
     transport_layers: Option<String>,
-) -> Result<qemu_server::QemuTransportLayer, ()> {
+) -> Result<spdm::TransportLayer, ()> {
     if let Some(t) = transport_layers {
         match t.as_str() {
-            "TRANS_DOE" => Ok(qemu_server::QemuTransportLayer::Doe),
-            "TRANS_MCTP" => Ok(qemu_server::QemuTransportLayer::Mctp),
+            "TRANS_DOE" => Ok(spdm::TransportLayer::Doe),
+            "TRANS_MCTP" => Ok(spdm::TransportLayer::Mctp),
             _ => {
                 error!("Unsupported QEMU transport layer");
                 Err(())

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -6,6 +6,7 @@
 //! to implement and emulate an SPDM responder.
 //!
 
+use crate::spdm::TransportLayer;
 use crate::*;
 use libspdm::spdm::LIBSPDM_MAX_SPDM_MSG_SIZE;
 use once_cell::sync::OnceCell;
@@ -24,13 +25,6 @@ static mut SEND_BUFFER: OnceCell<[u8; SEND_RECEIVE_BUFFER_LEN]> = OnceCell::new(
 static mut RECEIVE_BUFFER: OnceCell<[u8; SEND_RECEIVE_BUFFER_LEN]> = OnceCell::new();
 
 static mut CLIENT_CONNECTION: OnceCell<TcpStream> = OnceCell::new();
-
-/// Emulated transport layer in QEMU
-#[derive(Debug)]
-pub enum QemuTransportLayer {
-    Doe,
-    Mctp,
-}
 
 /// # Summary
 ///
@@ -310,7 +304,7 @@ unsafe extern "C" fn qemu_release_receiver_buffer(
 pub fn register_device(
     context: *mut c_void,
     port: u16,
-    transport: QemuTransportLayer,
+    transport: TransportLayer,
 ) -> Result<(), ()> {
     let buffer_send = [0; SEND_RECEIVE_BUFFER_LEN];
     let buffer_receive = [0; SEND_RECEIVE_BUFFER_LEN];
@@ -348,7 +342,7 @@ pub fn register_device(
         RECEIVE_BUFFER.set(buffer_receive).unwrap();
 
         match transport {
-            QemuTransportLayer::Doe => {
+            TransportLayer::Doe => {
                 libspdm_register_device_io_func(
                     context,
                     Some(qemu_send_message_doe),

--- a/src/usb_i2c.rs
+++ b/src/usb_i2c.rs
@@ -1,0 +1,387 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2024, Western Digital Corporation or its affiliates.
+
+//! This file provides support for interfacing to an USB-I2C/SMBUS device.
+//! Note: Currently, it designed to work exclusively with the libtock-rs
+//! [TODO: ADD REF WHEN UPSTREAM] app. However, can be modified easily to
+//! work with similar tools.
+//!
+//! The following topology is used:
+//!
+//! [HOST MACHINE] <--UART--> [USB_I2C_BRIDGE_DEVICE] <--I2C/SmBus--> [TARGET_ENDPOiNT]
+//!
+//! Where SPDM data messages are transported from the host to the bridge device
+//! over UART.It is then that devices responsibility to forward the SPDM
+//! messages to the target endpoint. This can be used on platforms for
+//! testing SPDM/MCTP over SMBUS. Particularly useful for machines that do not
+//! have I2C/SMBUS pinouts exposed.
+//!
+//! This depends on `-DLIBSPDM_ENABLE_CAPABILITY_CHUNK_CAP=1`, see README for how to
+//! enable chunking support when building libspdm.
+//!
+//! SAFETY: This file includes unsafe Rust.
+//!
+use crate::*;
+use core::ffi::c_void;
+use lazy_static::lazy_static;
+use once_cell::sync::OnceCell;
+use serialport::SerialPort;
+use std::io::Read;
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::sync::Mutex;
+use std::time::Duration;
+
+// Matching size for the tock-responder
+pub const LIBSPDM_MAX_SPDM_MSG_SIZE: u32 = 1906;
+// We are using libspdm chunking, so let's use smaller transfer chunks at the hardware
+// layer.
+const SEND_RECEIVE_BUFFER_LEN: usize = 128 as usize;
+static mut SEND_BUFFER: OnceCell<[u8; SEND_RECEIVE_BUFFER_LEN]> = OnceCell::new();
+static mut RECEIVE_BUFFER: OnceCell<[u8; SEND_RECEIVE_BUFFER_LEN]> = OnceCell::new();
+/// The length of the packet header sent prior to the SPDM data message by the
+/// usb-i2c bridge device. This packet is used to determine the exact length
+/// of the next incoming data set which contains only the SPDM message data.
+pub const HEADER_LEN: usize = 0x4;
+
+lazy_static! {
+    // Let's lock down the serial port, so we don't have to keep opening and
+    // closing it on every send/recv. Avoid the syscall overhead.
+    static ref SERIAL_PORT: Mutex<Option<Box<dyn SerialPort>>> = Mutex::new(None);
+}
+
+/// # Summary
+///
+/// Write the SPDM message buffer to the serial port specified by @SERIAL_PORT
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_send_message(
+    _context: *mut c_void,
+    message_size: usize,
+    message_ptr: *const c_void,
+    _timeout: u64,
+) -> u32 {
+    assert!(message_size < SEND_RECEIVE_BUFFER_LEN as usize);
+    let message = message_ptr as *const u8;
+    let msg_buf = unsafe { from_raw_parts(message, message_size) };
+    let mut send_buf: [u8; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize] =
+        [0; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize];
+
+    send_buf[0] = 0xAA; // Preamble
+    send_buf[1] = 0x22; // Target Address. TODO: Make configurable
+                        // Set the 16-bit length value [2] -> upper byte, [3] -> lower byte
+    send_buf[2..=3].copy_from_slice(&u16::to_be_bytes(message_size as u16));
+
+    // Copy the SPDM message buffer into the send buffer
+    assert!(send_buf.len() >= HEADER_LEN + msg_buf.len());
+    send_buf[HEADER_LEN..HEADER_LEN + msg_buf.len()].copy_from_slice(&msg_buf);
+
+    // For writes, we transfer the entire buffer of fixed length.
+    debug!(
+        "SPDM Message Length {:} || Total TX Length {:?}",
+        message_size,
+        send_buf.len()
+    );
+
+    debug!(
+        "Sending message {:x?}",
+        &send_buf[..HEADER_LEN + msg_buf.len()]
+    );
+
+    // Write out the data buffer
+    let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
+    port.write(&send_buf).expect("Write failed!");
+    info!("Sent!");
+
+    *SERIAL_PORT.lock().unwrap() = Some(port);
+
+    0
+}
+
+/// # Summary
+///
+/// Read data from @SERIAL_PORT until we hit end of line.
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `SEND_RECEIVE_BUFFER_LEN` to capture the received bytes.
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_receive_message(
+    _context: *mut c_void,
+    message_size: *mut usize,
+    message_ptr: *mut *mut c_void,
+    _timeout: u64,
+) -> u32 {
+    let message = *message_ptr as *mut u8;
+    let spdm_msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+
+    info!("Receiving message");
+
+    let preamble: [u8; 2] = [0xBB, 0xFF];
+    let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
+    assert_eq!(port.bytes_to_read().unwrap(), 0);
+    let mut header: Vec<u8> = vec![0; HEADER_LEN];
+    let mut i = 0;
+    _ = port.read_exact(&mut header).unwrap();
+
+    // Note: This is to address an odd quirk, where after usb-i2c device is newly
+    // flashed (first time) with the libtock-rs app, the first transfer from the
+    // device to us may have an odd offset, as if the TX buffer is non-empty
+    // (perhaps the end of the board boot banner lingering in the internal buffers).
+    loop {
+        if header
+            .windows(preamble.len())
+            .any(|window| window == preamble)
+            && header[0] == 0xBB
+        {
+            // Matched with entire header packet
+            break;
+        } else if header
+            .windows(preamble.len())
+            .any(|window| window == preamble)
+            && header[2] == 0xBB
+        {
+            // Preamble matches but with an offset of 2
+            let (first_part, second_part) = header.split_at_mut(2);
+            // Swap the elements of the two parts
+            first_part.swap_with_slice(second_part);
+            // Get the next two bytes of the header packet
+            port.read_exact(&mut header[2..]).unwrap();
+            break;
+        }
+        _ = port.read_exact(&mut header).unwrap();
+        i += 1;
+        if i > 10 {
+            // If we keep looping here, then the packet header is likely not
+            // going to be received.
+            panic!("RX data corrupted");
+        }
+    }
+
+    // Assert the header first
+    debug!("packet_header: {:x?}", header);
+    assert_eq!(header[0], 0xBB); // Receive Preamble 1
+    assert_eq!(header[1], 0xFF); // Receive Preamble 2 (This is just misc)
+
+    // Copy in the 2 bytes (Big Endian as set by target) that corresponds to the
+    // SPDM message length
+    *message_size = u16::from_be_bytes([header[2], header[3]]) as usize;
+    debug!("spdm_msg_len: {:x?}", *message_size);
+    assert!(*message_size <= SEND_RECEIVE_BUFFER_LEN);
+    // SPDM Data length should be non-zero
+    assert_ne!(*message_size, 0x00);
+
+    // Read the next set of data, which is just the SPDM message
+    port.read_exact(&mut spdm_msg_buf[0..*message_size])
+        .unwrap();
+    debug!("spdm_msg_data: {:x?}", *message_size);
+
+    *SERIAL_PORT.lock().unwrap() = Some(port);
+
+    0
+}
+
+/// # Summary
+///
+/// A helper function to capture the SEND_BUFFER into `msg_buf_ptr`
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `max_msg_size`: Returns the length of the sender buffer
+/// * `msg_buf_ptr`: Returns a pointer to the sender buffer (mutable)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the SEND_BUFFER is not available
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_acquire_sender_buffer(
+    _context: *mut c_void,
+    msg_buf_ptr: *mut *mut c_void,
+) -> u32 {
+    let mut buf = SEND_BUFFER.take().unwrap();
+    let buf_ptr = buf.as_mut_ptr() as *mut _ as *mut c_void;
+
+    *msg_buf_ptr = buf_ptr;
+
+    0
+}
+
+/// # Summary
+///
+/// A helper function to reset the SEND_BUFFER from `msg_buf_ptr`
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `msg_buf_ptr`: A pointer representing the sender buffer.
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the `msg_buf_ptr` is invalid or has less elements
+/// than `SEND_RECEIVE_BUFFER_LEN`
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_release_sender_buffer(
+    _context: *mut c_void,
+    msg_buf_ptr: *const c_void,
+) {
+    let message = msg_buf_ptr as *const u8;
+    let msg_buf = from_raw_parts(message, SEND_RECEIVE_BUFFER_LEN);
+
+    SEND_BUFFER.set(msg_buf.try_into().unwrap()).unwrap();
+}
+
+/// # Summary
+///
+/// A helper function to capture the RECEIVE_BUFFER into `msg_buf_ptr`
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `max_msg_size`: Returns the length of the receiver buffer
+/// * `msg_buf_ptr`: Returns a pointer to the receiver buffer (mutable)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the SEND_BUFFER is not available
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_acquire_receiver_buffer(
+    _context: *mut c_void,
+    msg_buf_ptr: *mut *mut c_void,
+) -> u32 {
+    let mut buf = RECEIVE_BUFFER.take().unwrap();
+    let buf_ptr = buf.as_mut_ptr() as *mut _ as *mut c_void;
+
+    *msg_buf_ptr = buf_ptr;
+
+    0
+}
+
+/// # Summary
+///
+/// A helper function to reset the RECEIVE_BUFFER from `msg_buf_ptr`
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `msg_buf_ptr`: A pointer representing the receiver buffer.
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the `msg_buf_ptr` is invalid or has less elements
+/// than `SEND_RECEIVE_BUFFER_LEN`
+#[no_mangle]
+unsafe extern "C" fn usb_i2c_release_receiver_buffer(
+    _context: *mut c_void,
+    msg_buf_ptr: *const c_void,
+) {
+    let message = msg_buf_ptr as *const u8;
+    let msg_buf = from_raw_parts(message, SEND_RECEIVE_BUFFER_LEN);
+
+    RECEIVE_BUFFER.set(msg_buf.try_into().unwrap()).unwrap();
+}
+
+/// # Summary
+///
+/// # Parameter
+///
+/// * `context`: The SPDM context
+///
+/// # Returns
+///
+/// Ok(()) on success
+///
+/// # Panics
+///
+/// Panics if `SEND_BUFFER/RECEIVE_BUFFER` is occupied
+pub fn register_device(
+    context: *mut c_void,
+    usb_dev: Option<String>,
+    usb_baud: u32,
+) -> Result<(), ()> {
+    let buffer_send = [0; SEND_RECEIVE_BUFFER_LEN];
+    let buffer_receive = [0; SEND_RECEIVE_BUFFER_LEN];
+
+    let udev = usb_dev.expect("USB device path not specified");
+
+    let port = serialport::new(&udev, usb_baud)
+        .timeout(Duration::from_secs(30))
+        .open()
+        .expect("Failed to open port");
+
+    // Clear I/O buffers to drop any misc/lingering data
+    port.clear(serialport::ClearBuffer::All)
+        .expect("Failed to clear buffer for {udev}");
+    assert_eq!(port.bytes_to_read().unwrap(), 0);
+    assert_eq!(port.bytes_to_write().unwrap(), 0);
+
+    info!("Serial Port {:} at {:} bits/s", &udev, usb_baud);
+
+    SERIAL_PORT.lock().unwrap().replace(port);
+
+    unsafe {
+        SEND_BUFFER.set(buffer_send).unwrap();
+        RECEIVE_BUFFER.set(buffer_receive).unwrap();
+
+        libspdm_register_device_io_func(
+            context,
+            Some(usb_i2c_send_message),
+            Some(usb_i2c_receive_message),
+        );
+        libspdm_register_device_buffer_func(
+            context,
+            SEND_RECEIVE_BUFFER_LEN as u32,
+            SEND_RECEIVE_BUFFER_LEN as u32,
+            Some(usb_i2c_acquire_sender_buffer),
+            Some(usb_i2c_release_sender_buffer),
+            Some(usb_i2c_acquire_receiver_buffer),
+            Some(usb_i2c_release_receiver_buffer),
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Overview

Add transport layer support for using a uart-i2c bridge tool. Currently, designed to work with the libtock-rs usb-i2c sample app (not upstream yet).  The general idea is that, we wrap the SPDM data buffer with some metadata that includes the target destination and data length. This is then written to the bridge device over UART which then parses and write the SPDM message buffer to the target endpoint over I2C/SMBus. The endpoint will master the bus (as per MCTP), and write the response back to the bridge device, that then wraps the SPDM buffer in metadata before writing it back to host (spdm-utils).

This depends on **`libspdm chunking support`** (see README updates). We use chunking to send digestible buffers to the target. Without chunking we would need to be transferring buffers of size > 1Kb per burst. Meaning the endpoint kernel buffer sizes would increase in memory footprint.

### Invocation

```
$ ./target/debug/spdm_utils --usb-i2c --usb-i2c-dev=/dev/ttyUSB0 --usb-i2c-baud=115200 request get-capabilities
```