### PR TITLE
build: drop -lrnglib dependancy

### DIFF
--- a/tock-responder/build.rs
+++ b/tock-responder/build.rs
@@ -10,7 +10,6 @@ fn main() {
     println!("cargo:rustc-link-arg=-ldebuglib");
     println!("cargo:rustc-link-arg=-lplatform_lib");
     println!("cargo:rustc-link-arg=-lcryptlib_mbedtls");
-    println!("cargo:rustc-link-arg=-lrnglib");
 
     println!("cargo:rustc-link-arg=-lmbedtls");
     println!("cargo:rustc-link-arg=-lmbedx509");


### PR DESCRIPTION
In accordance with the latest proposed changes to libspdm [1], we no longer need the rnglib implementation as we provide it to libspdm instead.

[1] https://github.com/DMTF/libspdm/pull/2486