### PR TITLE
tock-responder: Implement more libc stubs

### DIFF
--- a/tock-responder/src/libc_stubs.rs
+++ b/tock-responder/src/libc_stubs.rs
@@ -123,8 +123,69 @@ pub extern "C" fn time() {
 }
 
 #[no_mangle]
-pub extern "C" fn strncmp() {
-    todo!("libc/stub: strncmp(): not yet implemented");
+/// Compare no more than N characters of S1 and S2,
+/// returning less than, equal to or greater than zero
+/// if S1 is lexicographically less than, equal to or
+/// greater than S2.
+/// Based on: https://github.com/zerovm/glibc/blob/3f07350498160f552350dc39f6fe6d237c7c3b03/string/strncmp.c#L28C4-L29C20
+pub extern "C" fn strncmp(s1: *const c_char, s2: *const c_char, n: usize) -> i32 {
+    let mut s1 = s1;
+    let mut s2 = s2;
+    let mut n = n;
+
+    let mut c1: u8 = b'\0';
+    let mut c2: u8 = b'\0';
+
+    if n >= 4 {
+        let mut n4 = n >> 2;
+        while n4 > 0 {
+            c1 = unsafe { *s1 as u8 };
+            s1 = unsafe { s1.offset(1) };
+            c2 = unsafe { *s2 as u8 };
+            s2 = unsafe { s2.offset(1) };
+            if c1 == b'\0' || c1 != c2 {
+                return (c1 as i32) - (c2 as i32);
+            }
+            c1 = unsafe { *s1 as u8 };
+            s1 = unsafe { s1.offset(1) };
+            c2 = unsafe { *s2 as u8 };
+            s2 = unsafe { s2.offset(1) };
+            if c1 == b'\0' || c1 != c2 {
+                return (c1 as i32) - (c2 as i32);
+            }
+            c1 = unsafe { *s1 as u8 };
+            s1 = unsafe { s1.offset(1) };
+            c2 = unsafe { *s2 as u8 };
+            s2 = unsafe { s2.offset(1) };
+            if c1 == b'\0' || c1 != c2 {
+                return (c1 as i32) - (c2 as i32);
+            }
+            c1 = unsafe { *s1 as u8 };
+            s1 = unsafe { s1.offset(1) };
+            c2 = unsafe { *s2 as u8 };
+            s2 = unsafe { s2.offset(1) };
+            if c1 == b'\0' || c1 != c2 {
+                return (c1 as i32) - (c2 as i32);
+            }
+
+            n4 -= 1;
+        }
+        n &= 3;
+    }
+
+    while n > 0 {
+        c1 = unsafe { *s1 as u8 };
+        s1 = unsafe { s1.offset(1) };
+        c2 = unsafe { *s2 as u8 };
+        s2 = unsafe { s2.offset(1) };
+        if c1 == b'\0' || c1 != c2 {
+            return (c1 as i32) - (c2 as i32);
+        }
+
+        n -= 1;
+    }
+
+    (c1 as i32) - (c2 as i32)
 }
 
 #[no_mangle]


### PR DESCRIPTION
This adds support for `rand()` and `strncmp()`. With the implementation of `strncmp()` we can now issue `get-csr` to the device and view the certificate returned.

```shell
$ ./target/debug/spdm_utils --usb-i2c --usb-i2c-dev=/dev/ttyUSB0 --usb-i2c-baud=115200 request get-csr
...
$ openssl req -text -noout -inform der -verify -in ./csr_response.der

Certificate request self-signature verify OK
Certificate Request:
    Data:
        Version: 1 (0x0)
        Subject: C = AU, O = Western Digital Test, CN = Western Digital AN300 Test CSR
        Subject Public Key Info:
            Public Key Algorithm: id-ecPublicKey
                Public-Key: (384 bit)
                pub:
                    04:47:90:2a:40:bd:9f:60:50:b7:18:13:b2:2b:02:
                    b7:fa:33:a1:2d:df:70:a9:e2:e5:72:92:9a:e6:ba:
                    f9:04:2c:de:06:90:27:91:71:47:11:9e:1d:91:cb:
                    74:21:67:23:a1:77:58:fc:2a:99:41:ed:7b:7b:b9:
                    e7:ea:05:78:da:9d:b0:90:bd:c2:61:62:5d:4c:13:
                    cc:2f:8d:5b:fe:ad:38:f2:c7:24:82:4c:81:bc:d0:
                    f4:21:18:b7:1f:54:95
                ASN1 OID: secp384r1
                NIST CURVE: P-384
        Attributes:
            Requested Extensions:
                X509v3 Basic Constraints: 
                    CA:TRUE
                X509v3 Key Usage: 
                    ......0.
                X509v3 Subject Key Identifier: 
                    04:14:C5:B1:E4:D9:FF:5C:69:D0:57:9B:53:13:B3:21:E5:1E:6C:32:D8:A6
                X509v3 Extended Key Usage: 
                    .....0...+.........+.......0.
    Signature Algorithm: ecdsa-with-SHA384
    Signature Value:
        30:66:02:31:00:ff:a0:dd:1d:14:c9:ce:ca:dc:31:27:0b:66:
        96:02:2f:e0:ec:26:d6:1f:0c:33:e7:6d:5d:dd:9c:95:0d:34:
        3f:c5:ce:c9:2a:65:03:ff:5a:0a:f1:56:f6:e6:6c:e3:85:02:
        31:00:af:63:47:c1:85:b0:0b:0d:04:62:a7:5a:56:05:34:73:
        5e:7e:68:c6:8d:de:4c:be:ce:bd:fe:3b:a5:b7:65:e4:f2:30:
        a1:2c:a1:7e:7e:5c:b9:1e:67:03:88:8b:3c:d5
```