### PR TITLE
spdm: limited implementation of SPDM1.3 GET_CSR support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -405,7 +405,8 @@ fn main() -> Result<(), ()> {
             .unwrap();
             num_provisioned_slots += 1;
             assert!(num_provisioned_slots < 8);
-            responder::set_supported_slots_mask(num_provisioned_slots, ver, cntx_ptr).expect("failed to set supported slot mask");
+            responder::set_supported_slots_mask(num_provisioned_slots, ver, cntx_ptr)
+                .expect("failed to set supported slot mask");
 
             responder::response_loop(cntx_ptr);
         }


### PR DESCRIPTION
This implements the `libspdm_gen_csr_ex()` fn to allow us
to continue to support a `GET_CSR` in libspdm SPDM >= 1.3. This is limited
in the sense that we don't support CsrTrackingTags yet.

That is, a responder will immediately process the request and return the
CSR without needing a reset, as such, a requester must not request to
seek a CsrTrackingTag. Assertions are in place to catch such a case.