### PR TITLE
spdm: add manifest cbor enc/dec support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,10 @@ target
 certs/alias.*
 certs/end_*
 certs/bundle*
+
+certs/slot*/alias.*
+certs/slot*/end_*
+certs/slot*/bundle*
+certs/slot*/immutable.sha
+manifest.cbor
+

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,5 @@ certs/slot*/end_*
 certs/slot*/bundle*
 certs/slot*/immutable.sha
 manifest.cbor
+manifest/manifest.out.cbor
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,7 @@ dependencies = [
  "log",
  "memmap2",
  "once_cell",
+ "pyo3",
  "serialport",
  "sha2",
 ]
@@ -29,9 +30,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e2e1ebcb11de5c03c67de28a7df593d32191b44939c482e97702baaaa6ab6a5"
+checksum = "96b09b5178381e0874812a9b157f7fe84982617e48f71f4e3235482775e5b540"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -74,6 +75,12 @@ dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bindgen"
@@ -152,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e578d6ec4194633722ccf9544794b71b1385c3c027efe0c55db226fc880865c"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -162,9 +169,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.4.18"
+version = "4.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4df4df40ec50c46000231c914968278b1eb05098cf8f1b3a518a95030e71d1c7"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
 dependencies = [
  "anstream",
  "anstyle",
@@ -174,21 +181,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.4.7"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9804afaaf59a91e75b022a30fb7229a7901f60c755489cc61c9b423b836442"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702fc72eb24e5a1e48ce58027a675bc24edd52096d5397d4aea7c6dd9eca0bd1"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
 
 [[package]]
 name = "colorchoice"
@@ -233,9 +240,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
 name = "embedded-crc-macros"
@@ -290,9 +297,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0c62115964e08cb8039170eb33c1d0e2388a256930279edca206fff675f82c3"
+checksum = "bd5256b483761cd23699d0da46cc6fd2ee3be420bbe6d020ae4a091e70b7e9fd"
 
 [[package]]
 name = "home"
@@ -310,6 +317,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
+name = "indoc"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e186cfbae8084e513daff4240b4797e342f988cecda4fb6c939150f96315fd8"
+
+[[package]]
 name = "io-kit-sys"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -321,12 +334,12 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
+checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
 dependencies = [
  "hermit-abi",
- "rustix",
+ "libc",
  "windows-sys 0.52.0",
 ]
 
@@ -394,6 +407,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
+name = "lock_api"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -421,6 +444,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -457,6 +489,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.48.5",
+]
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -464,9 +519,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.29"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2900ede94e305130c13ddd391e0ab7cbaeb783945ae07a279c268cb05109c6cb"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "proc-macro2"
@@ -478,12 +533,82 @@ dependencies = [
 ]
 
 [[package]]
+name = "pyo3"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a89dc7a5850d0e983be1ec2a463a171d20990487c3cfcd68b5363f1ee3d6fe0"
+dependencies = [
+ "cfg-if",
+ "indoc",
+ "libc",
+ "memoffset",
+ "parking_lot",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+ "unindent",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07426f0d8fe5a601f26293f300afd1a7b1ed5e78b2a705870c5f30893c5163be"
+dependencies = [
+ "once_cell",
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb7dec17e17766b46bca4f1a4215a85006b4c2ecde122076c562dd058da6cf1"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f738b4e40d50b5711957f142878cfa0f28e054aa0ebdfc3fd137a843f74ed3"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc910d4851847827daf9d6cdd4a823fbdaab5b8818325c5e97a86da79e8881f"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.49",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -577,6 +702,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ecd384b10a64542d77071bd64bd7b231f4ed5940fba55e98c3de13824cf3d7"
+
+[[package]]
 name = "smbus-pec"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -587,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
 
 [[package]]
 name = "syn"
@@ -604,14 +735,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "915aea9e586f80826ee59f8453c1101f9d1c4b3964cd2460185ee8e299ada496"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
 
 [[package]]
 name = "termcolor"
@@ -624,22 +761,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.49",
 ]
 
 [[package]]
@@ -662,6 +799,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unindent"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,8 @@ sha2 = { version = "0.10", optional = true}
 env_logger = { version = "0.10", optional = true}
 
 libmctp = { git = "https://github.com/westerndigitalcorporation/libmctp.git" }
+
+[dependencies.pyo3]
+version = "0.20.2"
+features = ["auto-initialize", "abi3-py312"]
+

--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ You will also need a few host dependencies
 sudo dnf install cmake clang-libs clang-devel pciutils-devel openssl openssl-devel
 ```
 
+## Python
+
+spdm-utils requires the [cbor2](https://pypi.org/project/cbor2/) python module for manifest encoding and decoding. It can be installed with:
+
+```
+$ pip install cbor2
+```
+
 # Building
 
 Initialise all sub-modules

--- a/build.rs
+++ b/build.rs
@@ -90,4 +90,25 @@ fn main() {
             .output()
             .expect("Failed to execute command");
     }
+
+    // This script generates a `manifest.out.cbor` file that
+    // is the serialised measurement manifest, to be used
+    // by spdm-utils in response to a `get-measuremets`
+    // SPDM request.
+    if !Path::new("manifest/encode_cbor.py").is_file() {
+        panic!("cbor encode script not found!");
+    }
+
+    let rc = Command::new("python3")
+        .arg("encode_cbor.py")
+        .current_dir(env::current_dir().unwrap().join("manifest"))
+        .output()
+        .expect("Failed to execute encode_cbor");
+
+    if !rc.status.success() {
+        panic!(
+            "failed to generate serialized CBOR manifest: {:?}",
+            rc.status
+        )
+    }
 }

--- a/manifest/encode_cbor.py
+++ b/manifest/encode_cbor.py
@@ -1,0 +1,48 @@
+# This script reads in a CBOR input from a `manifest.in.cbor`` file and
+# generates a serialised stream from it and saves this in a `manifest.out.cbor`.
+# The serialised stream is to be used by spdm-utils.
+import cbor2
+
+try:
+    # Fetch all the bytes from our manifest file
+    with open('manifest.in.cbor', 'r') as file:
+        # Read all the bytes
+        input_cbor = file.read()
+except FileNotFoundError:
+    print("Error: manifest.in.cbor not found.")
+    exit(1)
+except Exception as e:
+    print(f"Error reading manifest.in.cbor: {e}")
+    exit(2)
+
+try:
+    # Serialize
+    encoded_data =  cbor2.dumps(input_cbor, string_referencing=True, canonical=True)
+except Exception as e:
+    print(f"Error encoding CBOR: {e}")
+    exit(1)
+
+print(f"Encoded CBOR Hex Stream")
+print(encoded_data.hex())
+
+try:
+    decoded_bytes = cbor2.loads(encoded_data)
+except Exception as e:
+    print(f"Error decoding CBOR: {e}")
+    exit(1)
+
+# Make sure we can decode back to the original
+assert input_cbor == decoded_bytes
+
+try:
+    # Create/overwrite (if existing) a file and write the encoded
+    # cbor stream to it.
+    with open('manifest.out.cbor', 'wb') as file:
+        file.write(encoded_data)
+
+except Exception as e:
+    print(f"Error writing encoded cbor hex stream to file: {e}")
+    exit(1)
+
+print("CBOR Encoded byte stream written to manifest.out.cbor")
+

--- a/src/libspdm/lib.rs
+++ b/src/libspdm/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 
 #[macro_use]
 pub mod libspdm_rs;
+pub mod manifest;
 #[macro_use]
 pub mod spdm;
 pub mod responder;

--- a/src/libspdm/manifest.rs
+++ b/src/libspdm/manifest.rs
@@ -40,17 +40,8 @@ impl Manifest {
             }
         };
 
-        let mut temp_buffer = Vec::new();
-        manifest.read_to_end(&mut temp_buffer)?;
-
-        assert!(temp_buffer.len() <= buffer.len());
-
-        // Copy over the manifest bytes to the actual buffer
-        for i in 0..temp_buffer.len() {
-            buffer[i] = temp_buffer[i];
-        }
-
-        Ok(temp_buffer.len())
+        let bytes_read = manifest.read(buffer).expect("failed reading manifest file");
+        Ok(bytes_read)
     }
 }
 

--- a/src/libspdm/manifest.rs
+++ b/src/libspdm/manifest.rs
@@ -1,0 +1,80 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2024, Western Digital Corporation or its affiliates.
+
+use std::fs::File;
+use std::io::Read;
+use std::path::Path;
+
+struct Manifest {}
+
+impl Manifest {
+    /// # Summary
+    ///
+    /// Reads the manifest from a file as specified by @path
+    /// This manifest must be in serialised CBOR form. This function
+    /// does not guarantee the correctness of the data read from @path. It simply
+    /// loads it
+    ///
+    /// # Parameter
+    ///
+    /// * `buffer`: A buffer to create a manifest into, should be a minimum
+    ///             size of LIBSPDM_MEASUREMENT_MANIFEST_SIZE.
+    ///
+    /// * `path`: Relative path the manifest file
+    ///
+    /// # Returns
+    ///
+    /// Ok(()) on success
+    ///
+    /// # Panics
+    ///
+    /// Panics on any errors related to failed file I/Os
+    /// Panics if the buffer size is less than required
+    fn read_manifest_from_file(buffer: &mut [u8], path: &Path) -> Result<usize, std::io::Error> {
+        let mut manifest = match File::open(path) {
+            Ok(manifest) => manifest,
+            Err(e) => {
+                println!("Error opening manifest file at {:?}, {:?}", path, e);
+                return Err(e);
+            }
+        };
+
+        let mut temp_buffer = Vec::new();
+        manifest.read_to_end(&mut temp_buffer)?;
+
+        assert!(temp_buffer.len() <= buffer.len());
+
+        // Copy over the manifest bytes to the actual buffer
+        for i in 0..temp_buffer.len() {
+            buffer[i] = temp_buffer[i];
+        }
+
+        Ok(temp_buffer.len())
+    }
+}
+
+/// # Summary
+///
+/// Reads the manifest from a file as specified by @path
+/// This manifest must be in serialised CBOR form. This function
+/// does not guarantee the correctness of the data read from @path. It simply
+/// loads it
+///
+/// # Parameter
+///
+/// * `buffer`: A buffer to create a manifest into, should be a minimum size of
+///             LIBSPDM_MEASUREMENT_MANIFEST_SIZE.
+/// * `path`: Relative path to the manifest file
+///
+/// # Returns
+///
+/// Ok(size) on success, where size is the num bytes of the manifest
+///
+/// # Panics
+///
+/// Panics on any errors related to failed file I/Os
+pub fn fetch_local_manifest(buffer: &mut [u8], path: &Path) -> Result<usize, ()> {
+    let len = Manifest::read_manifest_from_file(buffer, &path).expect("failed to read manifest");
+    Ok(len)
+}

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -14,6 +14,7 @@
 use crate::libspdm_rs;
 // TODO: Remove this
 use crate::libspdm_rs::*;
+use crate::manifest;
 use core::ffi::c_void;
 use core::fmt;
 use core::ptr;
@@ -1317,9 +1318,12 @@ unsafe fn libspdm_fill_measurement_manifest_block(
     use_bit_stream: bool,
     measurement_hash_algo: u32,
 ) -> usize {
-    let data = [0; LIBSPDM_MEASUREMENT_MANIFEST_SIZE as usize];
+    let mut data = [0; LIBSPDM_MEASUREMENT_MANIFEST_SIZE as usize];
     let hash_size = libspdm_rs::libspdm_get_measurement_hash_size(measurement_hash_algo) as usize;
-    let size = data.len();
+    // Fetch an already generated manifest.
+    let manifest_path = Path::new("manifest/manifest.out.cbor");
+    let size =
+        manifest::fetch_local_manifest(&mut data, manifest_path).expect("failed to read manifest");
 
     (*measurement_block).measurement_block_common_header.index =
         SPDM_MEASUREMENT_BLOCK_MEASUREMENT_INDEX_MEASUREMENT_MANIFEST as u8;


### PR DESCRIPTION
## Overview

This adds support to spdm-utils to be able to cbor serialise a `manifest.in.cbor` file at compile time, then use the output binary file created as the `measurement manifest` to be used during a `get-measurements` index `0xFD` request.

The requester is also now able to decode this received manifest and print it out to the user in a human readable format.

Note: That the file `manifest.in.cbor` is left blank on purpose, such that a user can fill it out as required.