### PR TITLE
Implement remaining TCG Certificate Checks

### DIFF
--- a/src/tcg_concise_evidence_binding.rs
+++ b/src/tcg_concise_evidence_binding.rs
@@ -156,7 +156,7 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
 
                         if seq.1 == ID_DMTF_HARDWARE_IDENTITY {
                             // This contains id-DMTF-hardware-identity
-                            debug!("'{}' contains id-DMTF-hardware-identity", x509.subject());
+                            info!("'{}' contains id-DMTF-hardware-identity", x509.subject());
 
                             // Assert that mutable isn't set
                             // TODO: Support multiple entries in id-spdm-cert-oids
@@ -250,7 +250,7 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
 
                         if seq.1 == ID_DMTF_MUTABLE_CERTIFICATE {
                             // This contains id-DMTF-mutable-certificate
-                            debug!("'{}' contains id-DMTF-mutable-certificate", x509.subject());
+                            info!("'{}' contains id-DMTF-mutable-certificate", x509.subject());
                         }
 
                         assert!(seq.1 == ID_DMTF_MUTABLE_CERTIFICATE);
@@ -270,7 +270,7 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
                 }
             }
             SPDMCertificateType::LeadCert => {
-                debug!("'{}' is the Leaf Cert", x509.subject());
+                info!("'{}' is the Leaf Cert", x509.subject());
             }
         }
     }

--- a/src/tcg_concise_evidence_binding.rs
+++ b/src/tcg_concise_evidence_binding.rs
@@ -207,10 +207,7 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
                                 }
                             }
                         } else {
-                            // This is the first Alias Intermediate Certificate
-                            cert_type = SPDMCertificateType::AlisasCertCA;
-
-                            debug!("{:?}", x509);
+                            unreachable!();
                         }
                     }
                     Ok(None) => {

--- a/src/tcg_concise_evidence_binding.rs
+++ b/src/tcg_concise_evidence_binding.rs
@@ -193,7 +193,6 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
                                             // As the next certificate is an Alias Intermediate
                                             // Certificate, then this certificate is used to issue
                                             // Intermediate CA certificates.
-                                            // There fore TCG requires these
                                             info!("    Used to sign ECA");
                                             check_for_extensions(
                                                 &x509,
@@ -281,7 +280,7 @@ pub fn check_tcg_dice_evidence_binding(cert_slot_id: u8) -> Result<(), ()> {
                 // As the next certificate is an Alias Intermediate
                 // Certificate, then this certificate is used to issue
                 // Intermediate CA certificates.
-                // There fore TCG requires these
+                // Therefore TCG requires these
                 info!("    Used to sign ECA");
                 check_for_extensions(&x509, "tcg-dice-kp-eca", &TCG_DICE_KP_ECA)?;
                 check_for_basic_contraints_ca(&x509, true)?;

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -31,6 +31,9 @@ pub enum TestBackend {
 /// any assertions within the requests can be validated. This function does not
 /// do any additional testing outside of the what the requests do.
 ///
+/// This will only pass when run against a device that meets the
+/// "TCG DICE Concise Evidence Binding for SPDM" specification.
+///
 /// # Parameter
 ///
 /// * `cntx`: The SPDM context
@@ -38,7 +41,7 @@ pub enum TestBackend {
 /// # Returns
 ///
 /// Success, or any errors returned by the request.
-pub fn do_requests_checks(cntx: *mut c_void) -> Result<(), u32> {
+pub fn do_tcg_dice_evidence_binding_request_checks(cntx: *mut c_void) -> Result<(), u32> {
     // Setup Basic Requester, this is the default config we use for spdm-utils.
     request::setup_capabilities(
         cntx,
@@ -116,6 +119,7 @@ pub fn do_requests_checks(cntx: *mut c_void) -> Result<(), u32> {
     info!("Start RequestCode::GetCsr");
     request::prepare_request(cntx, RequestCode::GetCsr {}, 0, None, &mut session_info)?;
     info!(" RequestCode::GetCsr ... [OK]");
+
     Ok(())
 }
 
@@ -140,13 +144,13 @@ pub unsafe fn start_tests(cntx: *mut c_void, backend: TestBackend) -> ! {
             test_discovery_basic().unwrap();
             test_discovery_all().unwrap();
             test_discovery_error().unwrap();
-            if let Err(libpsm_err) = do_requests_checks(cntx) {
+            if let Err(libpsm_err) = do_tcg_dice_evidence_binding_request_checks(cntx) {
                 panic!("    request failed with libspdm err: {:x}", libpsm_err);
             }
         }
         TestBackend::SocketBackend => {
             responder_validator_tests(cntx).unwrap();
-            if let Err(libpsm_err) = do_requests_checks(cntx) {
+            if let Err(libpsm_err) = do_tcg_dice_evidence_binding_request_checks(cntx) {
                 panic!("    request failed with libspdm err: {:x}", libpsm_err);
             }
         }
@@ -672,9 +676,9 @@ pub unsafe fn responder_validator_tests(context: *mut c_void) -> Result<(), ()> 
             context,
             &m_spdm_responder_validator_config as *const common_test_suite_config_t,
         );
-    }
 
-    info!("\n---- Responder-Validator Tests Complete. See `log` to check the results of libspdm tests ----\n");
+        info!("\n---- Responder-Validator Tests Complete. See `log` to check the results of libspdm tests ----\n");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Implement the remaining certificate checks to enforce the section "5.3 Certificate Contents" requirements.

There are still a few TODOs in the code. Mostly that we need to support multiple entries in the `id-spdm-cert-oids` `SEQUENCE` (section 414 of SPDM) and checking that the certificates are only used for what they are advertised for in seciont 5.3 of the TCG DICE Concise Evidence Binding for SPDM specification.

For single interactions via the command line we print the information for a human to review. We should look at integrating the results from `check_tcg_dice_evidence_binding()` into other requests in the test infrastructure to more accurately enforce requirements.