### PR TITLE
manifest: handle decode failures

### DIFF
--- a/src/libspdm/manifest.rs
+++ b/src/libspdm/manifest.rs
@@ -147,6 +147,9 @@ pub fn decode_cbor_manifest(buffer: &[u8], use_pretty: bool) -> Result<Vec<u8>, 
 
             return Ok(decoded_cbor);
         }
-        Err(e) => panic!("Ruby script {script} not found : error {}", e),
+        Err(e) => {
+            error!("Ruby script {script} not found : error {}", e);
+            return Err(());
+        }
     }
 }

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -649,41 +649,53 @@ pub unsafe fn get_measurement(context: *mut c_void, slot_id: u8) -> Result<(), u
             let measurement_manifest = &measurement_record
                 [LIBSPDM_MANIFEST_RAW_BITSTREAM_OFFSET..measurement_record_length as usize];
             // Save the manifest in CBOR diagnostic format
-            let decoded_bytes =
-                manifest::decode_cbor_manifest(&measurement_manifest, false).unwrap();
-            let path = Path::new("manifest/responder_manifest.cbor");
-            manifest::save_manifest_to_file(&decoded_bytes, path).unwrap();
-            info!(
-                "---Decoded measurement manifest {} received---",
-                "diagnostic".blue()
-            );
-            info!(
-                "\n{}",
-                String::from_utf8_lossy(&decoded_bytes).blue().bold()
-            );
-            info!(
-                "---Decoded measurement manifest {} end---",
-                "diagnostic".blue()
-            );
+            match manifest::decode_cbor_manifest(&measurement_manifest, false) {
+                Ok(decoded_bytes) => {
+                    let path = Path::new("manifest/responder_manifest.cbor");
+                    manifest::save_manifest_to_file(&decoded_bytes, path).unwrap();
+                    info!(
+                        "---Decoded measurement manifest {} received---",
+                        "diagnostic".blue()
+                    );
+                    info!(
+                        "\n{}",
+                        String::from_utf8_lossy(&decoded_bytes).blue().bold()
+                    );
+                    info!(
+                        "---Decoded measurement manifest {} end---",
+                        "diagnostic".blue()
+                    );
+                }
+                Err(_) => warn!("Failed to decode manifest into diagnostic format"),
+            }
 
             // Save the manifest in pretty format
-            let decoded_bytes =
-                manifest::decode_cbor_manifest(&measurement_manifest, true).unwrap();
-            let path = Path::new("manifest/responder_manifest.pretty");
-            manifest::save_manifest_to_file(&decoded_bytes, path).unwrap();
+            match manifest::decode_cbor_manifest(&measurement_manifest, true) {
+                Ok(decoded_bytes) => {
+                    let path = Path::new("manifest/responder_manifest.pretty");
+                    manifest::save_manifest_to_file(&decoded_bytes, path).unwrap();
 
-            info!(
-                "---Decoded measurement manifest {} received---",
-                "pretty".green()
-            );
-            info!(
-                "\n{}",
-                String::from_utf8_lossy(&decoded_bytes).green().bold()
-            );
-            info!(
-                "---Decoded measurement manifest {} end---",
-                "pretty".green()
-            );
+                    info!(
+                        "---Decoded measurement manifest {} received---",
+                        "pretty".green()
+                    );
+                    info!(
+                        "\n{}",
+                        String::from_utf8_lossy(&decoded_bytes).green().bold()
+                    );
+                    info!(
+                        "---Decoded measurement manifest {} end---",
+                        "pretty".green()
+                    );
+                }
+                Err(_) => warn!("Failed to decode manifest into pretty format"),
+            }
+
+            // Print the measurement manifest in raw-bitstream form(as received), as fail-safe
+            // incase we failed to decode.
+            debug!("---Measurement manifest {} start---", "raw-bitstream".red());
+            debug!("\n{:x?}", measurement_manifest);
+            debug!("---Measurement manifest {} end---", "raw-bitstream".red());
         }
     }
 


### PR DESCRIPTION
Instead of panic-ing, let's return an error on cases where we are unable to decode the measurement manifest.

This is useful, if the target platform does not have access to the decode utilities (`cbor-diag`). Such targets can still use spdm-utils to extract the raw-bitstream of the measurement manifest received, and skip decoding all together.

Such a case should only occur when running in `requester` mode, for examle and embedded platform with limited access to required libraries.