### PR TITLE
libspdm: Fix no_std build

### DIFF
--- a/src/libspdm/lib.rs
+++ b/src/libspdm/lib.rs
@@ -16,6 +16,7 @@ extern crate alloc;
 
 #[macro_use]
 pub mod libspdm_rs;
+#[cfg(not(feature = "no_std"))]
 pub mod manifest;
 #[macro_use]
 pub mod spdm;


### PR DESCRIPTION
This broke recently with some changes, fixup the build so the tock-responder can be built.