### PR TITLE
libspdm: Support generating direct manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,8 @@ dependencies = [
  "libmctp",
  "log",
  "memmap2",
+ "minicbor",
+ "minicbor-derive",
  "once_cell",
  "serialport",
  "sha2",
@@ -309,6 +311,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "der-parser"
@@ -420,6 +428,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,9 +505,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.154"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
 
 [[package]]
 name = "libloading"
@@ -564,6 +582,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.24.0"
+source = "git+https://gitlab.com/twittner/minicbor.git#64237efd4dc6a623b3b3780003fc98d5e144f03e"
+dependencies = [
+ "half",
+ "minicbor-derive",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.15.0"
+source = "git+https://gitlab.com/twittner/minicbor.git#64237efd4dc6a623b3b3780003fc98d5e144f03e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.60",
 ]
 
 [[package]]
@@ -744,18 +781,18 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "serde"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9846a40c979031340571da2545a4e5b7c4163bdae79b301d5f86d03979451fcc"
+checksum = "0c9f6e76df036c77cd94996771fb40db98187f096dd0b9af39c6c6e452ba966a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.198"
+version = "1.0.199"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88edab869b01783ba905e7d0153f9fc1a6505a96e4ad3018011eedb838566d9"
+checksum = "11bd257a6541e141e42ca6d24ae26f7714887b47e89aa739099104c7e4d3b7fc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 default = ["std"]
 
 no_std = []
-std = ["clap", "memmap2", "once_cell", "sha2", "env_logger", "serialport", "lazy_static", "colored", "which", "asn1-rs", "x509-parser"]
+std = ["clap", "memmap2", "once_cell", "sha2", "env_logger", "serialport", "lazy_static", "colored", "which", "asn1-rs", "x509-parser", "minicbor", "minicbor-derive"]
 
 [lib]
 name = "libspdm"
@@ -39,5 +39,7 @@ colored =  { version = "2.1", optional = true }
 which =  { version = "6.0", optional = true }
 asn1-rs = { version = "0.6", optional = true }
 x509-parser = { version = "0.15", optional = true }
+minicbor = { git = "https://gitlab.com/twittner/minicbor.git", features = ["half", "alloc", "std"], optional = true }
+minicbor-derive = { git = "https://gitlab.com/twittner/minicbor.git", features = ["alloc", "std"], optional = true }
 
 libmctp = { git = "https://github.com/westerndigitalcorporation/libmctp.git" }

--- a/src/libspdm/manifest.rs
+++ b/src/libspdm/manifest.rs
@@ -2,6 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 // Copyright (C) 2024, Western Digital Corporation or its affiliates.
 
+use crate::libspdm_rs;
+use crate::libspdm_rs::LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE;
+use crate::spdm::{get_base_hash_algo, get_measurement};
+use core::ffi::c_void;
+use core::slice::from_raw_parts;
+use minicbor::bytes::ByteSlice;
+use minicbor::data::Tagged;
+use minicbor_derive::{CborLen, Decode, Encode};
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
@@ -152,4 +160,221 @@ pub fn decode_cbor_manifest(buffer: &[u8], use_pretty: bool) -> Result<Vec<u8>, 
             return Err(());
         }
     }
+}
+
+pub type SpdmToc<'a> = Tagged<570, TaggedEvidence<'a>>;
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct TaggedEvidence<'a> {
+    #[b(0)]
+    tagged_evidence: [Tagged<571, CeEvTriples<'a>>; 1],
+    #[b(1)]
+    rim_locators: Vec<CorimLocatorMap<'a>>,
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct CeEvTriples<'a> {
+    #[b(0)]
+    ce_ev_triples: CeMembershipTriples<'a>,
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct CeMembershipTriples<'a> {
+    #[b(0)]
+    ce_membership_triples: (EnvironmentMap<'a>, Vec<MeasurementMap<'a>>),
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct EnvironmentMap<'a> {
+    #[b(0)]
+    class: Class<'a>,
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct Class<'a> {
+    #[b(0)]
+    id: Tagged<111, &'a ByteSlice>,
+    #[b(1)]
+    vendor: &'a str,
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct MeasurementMap<'a> {
+    // mkey
+    #[n(1)]
+    mval: MeasurementValuesMap<'a>,
+    #[b(2)]
+    authorised_by: [Tagged<554, &'a str>; 1],
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+/// https://github.com/ietf-rats-wg/draft-ietf-rats-corim/blob/main/cddl/measurement-values-map.cddl
+pub struct MeasurementValuesMap<'a> {
+    #[b(0)]
+    version: Option<&'a str>,
+    #[b(1)]
+    svn: Option<Tagged<552, i64>>,
+    #[b(2)]
+    digest: Option<(i64, &'a ByteSlice)>,
+    // ? &(flags: 3) => flags-map
+    #[b(4)]
+    raw_value: Option<Tagged<560, &'a ByteSlice>>,
+    // ? (
+    //     &(raw-value: 4) => $raw-value-type-choice,
+    //     ? &(raw-value-mask: 5) => raw-value-mask-type
+    //   )
+    // ? &(mac-addr: 6) => mac-addr-type-choice
+    // ? &(ip-addr: 7) =>  ip-addr-type-choice
+    // ? &(serial-number: 8) => text
+    // ? &(ueid: 9) => ueid-type
+    // ? &(uuid: 10) => uuid-type
+    #[b(11)]
+    name: Option<&'a str>,
+    #[b(12)]
+    spdm_indirect: Option<Index>, // ? &(cryptokeys: 13) => [ + $crypto-key-type-choice ]
+                                  // ? &(integrity-registers: 14) => integrity-registers
+}
+
+#[derive(Debug, Encode, Decode, CborLen)]
+#[cbor(map)]
+pub struct CorimLocatorMap<'a> {
+    #[b(0)]
+    link: Tagged<32, &'a str>,
+}
+
+#[derive(Debug, Encode, Decode, Clone, Copy, CborLen)]
+#[cbor(map)]
+pub struct Index {
+    #[n(0)]
+    index: [u8; 1],
+}
+
+const DEBUG_INFORMATION: u8 =
+    (crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_DEVICE_MODE
+        | crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM) as u8;
+const VERSION: u8 = (crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_VERSION
+    | crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM)
+    as u8;
+const SVN: u8 = (crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_SECURE_VERSION_NUMBER
+    | crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM)
+    as u8;
+const RAW_BIT_STREAM: u8 =
+    crate::libspdm_rs::SPDM_MEASUREMENT_BLOCK_MEASUREMENT_TYPE_RAW_BIT_STREAM as u8;
+const DIGESTS: u8 = RAW_BIT_STREAM - 1;
+
+/// This function converts indirect tagged-concise-evidence bindings to
+/// direct measurements.
+///
+/// The TCG Concise Evidence Binding for SPDM spec states that
+/// "If a lead Attester supports tagged-concise-evidence and an spdm-indirect
+/// measurement is used, the DMTFMeasurementValueType to CoMID measurement
+/// mapping SHOULD be applied according to Table 7."
+///
+/// This function will parse a Concise Evidence Binding manifest and replace
+/// the `spdm-indirect` entries with measurements.
+pub fn generate_direct_manifest(
+    context: *mut c_void,
+    slot_id: u8,
+    measurement_manifest: &[u8],
+) -> Result<SpdmToc, minicbor::decode::Error> {
+    let mut spdm_toc: SpdmToc<'_> = minicbor::decode(&measurement_manifest)?;
+    let ce_ev_triples = &mut spdm_toc
+        .value_mut()
+        .tagged_evidence
+        .first_mut()
+        .unwrap()
+        .value_mut()
+        .ce_ev_triples;
+    let measurement_maps = &mut ce_ev_triples.ce_membership_triples.1;
+
+    for measurement_map in measurement_maps {
+        if let Some(measurement_index) = measurement_map.mval.spdm_indirect {
+            let mut measurement_record = [0; LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE as usize];
+            let (dmtf_spec_measure_type, _measurement_record_length) = unsafe {
+                get_measurement(
+                    context,
+                    slot_id,
+                    measurement_index.index[0] as u32,
+                    &mut measurement_record,
+                )
+                .unwrap()
+            };
+
+            let measurement_offset =
+                core::mem::size_of::<libspdm_rs::spdm_measurement_block_dmtf_t>();
+            let measurement_block =
+                &measurement_record as *const _ as *const libspdm_rs::spdm_measurement_block_dmtf_t;
+            let measurement_size = unsafe {
+                (*measurement_block)
+                    .measurement_block_dmtf_header
+                    .dmtf_spec_measurement_value_size
+            };
+
+            match dmtf_spec_measure_type {
+                0..=DIGESTS => {
+                    // digests
+                    let msg_buf = unsafe {
+                        from_raw_parts(
+                            measurement_block.add(1) as *const u8,
+                            measurement_size.min(LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE as u16)
+                                as usize,
+                        )
+                    };
+                    let hash_algo = unsafe { get_base_hash_algo(context, slot_id).unwrap().0 };
+                    measurement_map.mval.digest = Some((hash_algo as i64, msg_buf.into()));
+                }
+                DEBUG_INFORMATION => {
+                    let msg_buf = unsafe {
+                        from_raw_parts(
+                            measurement_block.add(1) as *const u8,
+                            measurement_size.min(LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE as u16)
+                                as usize,
+                        )
+                    };
+                    measurement_map.mval.raw_value = Some(Tagged::new(msg_buf.into()));
+                }
+                VERSION => {
+                    let msg_buf = unsafe {
+                        from_raw_parts(
+                            measurement_block.add(1) as *const u8,
+                            measurement_size.min(LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE as u16)
+                                as usize,
+                        )
+                    };
+                    measurement_map.mval.version = Some(std::str::from_utf8(msg_buf).unwrap());
+                }
+                SVN => {
+                    let value = measurement_record[measurement_offset + 0] as i64
+                        | (measurement_record[measurement_offset + 1] as i64) << 8
+                        | (measurement_record[measurement_offset + 2] as i64) << 16
+                        | (measurement_record[measurement_offset + 3] as i64) << 24;
+
+                    measurement_map.mval.svn = Some(Tagged::<552, i64>::new(value));
+                }
+                RAW_BIT_STREAM | 0xFF => {
+                    // raw-value
+                    let msg_buf = unsafe {
+                        from_raw_parts(
+                            measurement_block.add(1) as *const u8,
+                            measurement_size.min(LIBSPDM_MAX_MEASUREMENT_RECORD_SIZE as u16)
+                                as usize,
+                        )
+                    };
+                    measurement_map.mval.raw_value = Some(Tagged::new(msg_buf.into()));
+                }
+                _ => {}
+            }
+
+            measurement_map.mval.spdm_indirect = None;
+        }
+    }
+
+    Ok(spdm_toc)
 }

--- a/tock-responder/Cargo.lock
+++ b/tock-responder/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "bindgen",
  "libmctp",
  "log",
+ "which 6.0.1",
 ]
 
 [[package]]
@@ -56,7 +57,7 @@ dependencies = [
  "rustc-hash",
  "shlex",
  "syn",
- "which",
+ "which 4.4.2",
 ]
 
 [[package]]
@@ -767,6 +768,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "6.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
+dependencies = [
+ "either",
+ "home",
+ "rustix",
+ "winsafe",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,3 +941,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"


### PR DESCRIPTION
This supports generating a direct manifest from an indirect manifest. This is based on the original discussion at [1].

1: https://gitlab.com/twittner/minicbor/-/merge_requests/39