### PR TITLE
Improve general error handling + PCIe Hex IDs

### DIFF
--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -8,6 +8,38 @@ use crate::*;
 
 /// # Summary
 ///
+/// Parses the string arguments that specifies the PCIe Vendor ID and Device ID.
+///
+/// # Parameter
+///
+/// * `vid`: specified as a hex string "0xCAF3" or as base 10 "1234".
+/// * `dev_id`: specified as a hex string "0xCAF3" or as base 10 "1234".
+///
+/// # Returns
+///
+/// On success, OK((vid, dev_id)) or Err(()) on failure to parse.
+pub fn parse_pcie_identifiers(vid: String, dev_id: String) -> Result<(u16, u16), ()> {
+    fn parse_identifier(id: String, id_type: &str) -> Result<u16, ()> {
+        let (id, base) = if id.starts_with("0x") {
+            (id.trim_start_matches("0x"), 16)
+        } else {
+            (id.as_str(), 10)
+        };
+
+        u16::from_str_radix(id, base).map_err(|e| {
+            error!("Invalid PCIe {id_type}: {:} - err {:?}", id, e);
+            ()
+        })
+    }
+
+    let vid = parse_identifier(vid, "vendor ID")?;
+    let dev_id = parse_identifier(dev_id, "device ID")?;
+
+    Ok((vid, dev_id))
+}
+
+/// # Summary
+///
 /// Parses the CLI argument for the SPDM version used by a responder.
 ///
 /// # Parameter

--- a/src/doe_pci_cfg.rs
+++ b/src/doe_pci_cfg.rs
@@ -302,9 +302,18 @@ pub fn register_device(context: *mut c_void, pcie_vid: u16, pcie_devid: u16) -> 
         devid: pcie_devid,
     };
     unsafe {
-        SEND_BUFFER.set(buffer_send).unwrap();
-        RECEIVE_BUFFER.set(buffer_receive).unwrap();
-        PCIE_IDENTIFIERS.set(pcie_ids).unwrap();
+        SEND_BUFFER.set(buffer_send).map_err(|e| {
+            error!("Failed to set send buffer: {e:?}");
+            ()
+        })?;
+        RECEIVE_BUFFER.set(buffer_receive).map_err(|e| {
+            error!("Failed to set receive buffer: {e:?}");
+            ()
+        })?;
+        PCIE_IDENTIFIERS.set(pcie_ids).map_err(|e| {
+            error!("Failed to set device PCIe Identifiers: {e:?}");
+            ()
+        })?;
 
         libspdm_register_device_io_func(
             context,

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -460,16 +460,24 @@ pub unsafe fn setup_transport_layer(
         data_ptr,
         core::mem::size_of::<u32>(),
     )) {
-        panic!("Unable to set data");
+        error!("Unable to set data");
+        return Err(());
     }
 
     let libspdm_scratch_buffer_size = libspdm_get_sizeof_required_scratch_buffer(context);
     let libspdm_scratch_buffer_layout =
-        Layout::from_size_align(libspdm_scratch_buffer_size, 8).unwrap();
+        match Layout::from_size_align(libspdm_scratch_buffer_size, 8) {
+            Ok(layout) => layout,
+            Err(e) => {
+                error!("Failed to generate layout: {:?}", e);
+                return Err(());
+            }
+        };
     let libspdm_scratch_buffer = alloc(libspdm_scratch_buffer_layout);
 
     if libspdm_scratch_buffer.is_null() {
-        panic!("Unable to allocate libspdm scratch buffer");
+        error!("Unable to allocate libspdm scratch buffer");
+        return Err(());
     }
 
     let libspdm_scratch_buffer_ptr: *mut c_void = libspdm_scratch_buffer as *mut _ as *mut c_void;

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,12 +41,12 @@ struct Args {
     doe_pci_cfg: bool,
 
     /// PCIe Identifier, Vendor ID of the SPDM supported device
-    #[arg(long, default_value_t = 0)]
-    pcie_vid: u16,
+    #[arg(long, default_value = "")]
+    pcie_vid: String,
 
     /// PCIe Identifier, Device ID of the SPDM supported device
-    #[arg(long, default_value_t = 0)]
-    pcie_devid: u16,
+    #[arg(long, default_value = "")]
+    pcie_devid: String,
 
     /// Use the Socket Server backend
     #[arg(long)]
@@ -309,9 +309,10 @@ fn main() -> Result<(), ()> {
     if cli.doe_pci_cfg {
         // Check that a device exists with provided vid/devid
         unsafe {
-            let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(cli.pcie_vid, cli.pcie_devid)?;
+            let (vid, dev_id) = cli_helpers::parse_pcie_identifiers(cli.pcie_vid, cli.pcie_devid)?;
+            let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(vid, dev_id)?;
             pci_cleanup(pacc);
-            doe_pci_cfg::register_device(cntx_ptr, cli.pcie_vid, cli.pcie_devid)?;
+            doe_pci_cfg::register_device(cntx_ptr, vid, dev_id)?;
         }
     } else if cli.socket_server {
         socket_server::register_device(cntx_ptr)?;

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -474,9 +474,18 @@ pub fn register_device(
     for client in listener.incoming() {
         match client {
             Ok(client_conn) => {
-                info!("New connection: {}", client_conn.peer_addr().unwrap());
+                info!(
+                    "New connection: {}",
+                    client_conn.peer_addr().map_err(|e| {
+                        error!("Failed to get socket address: {e:?}");
+                        ()
+                    })?
+                );
                 unsafe {
-                    CLIENT_CONNECTION.set(client_conn).unwrap();
+                    CLIENT_CONNECTION.set(client_conn).map_err(|e| {
+                        error!("Failed to set/save client connection {e:?}");
+                        ()
+                    })?;
                 }
                 break;
             }
@@ -487,8 +496,14 @@ pub fn register_device(
     }
 
     unsafe {
-        SEND_BUFFER.set(buffer_send).unwrap();
-        RECEIVE_BUFFER.set(buffer_receive).unwrap();
+        SEND_BUFFER.set(buffer_send).map_err(|e| {
+            error!("Failed to set send buffer: {e:?}");
+            ()
+        })?;
+        RECEIVE_BUFFER.set(buffer_receive).map_err(|e| {
+            error!("Failed to receive buffer: {e:?}");
+            ()
+        })?;
 
         match transport {
             TransportLayer::Doe => {

--- a/src/socket_server.rs
+++ b/src/socket_server.rs
@@ -277,7 +277,10 @@ pub fn register_device(context: *mut c_void) -> Result<(), ()> {
     let socket = Path::new(SOCKET_PATH);
 
     if socket.exists() {
-        fs::remove_file(socket).unwrap();
+        fs::remove_file(socket).map_err(|e| {
+            error!("Failed to remove out socket file {:?}", e);
+            ()
+        })?;
     }
 
     let stream = match UnixListener::bind(socket) {
@@ -298,7 +301,10 @@ pub fn register_device(context: *mut c_void) -> Result<(), ()> {
                 unsafe {
                     // TODO: It would be nice to somehow save this in libspdm
                     // context
-                    CLIENT_CONNECTION.set(client_connection).unwrap();
+                    CLIENT_CONNECTION.set(client_connection).map_err(|e| {
+                        error!("Failed to set/save client connection: {e:?}");
+                        ()
+                    })?;
                 }
                 info!("Client connected");
                 break;
@@ -311,8 +317,14 @@ pub fn register_device(context: *mut c_void) -> Result<(), ()> {
     }
 
     unsafe {
-        SEND_BUFFER.set(buffer_send).unwrap();
-        RECEIVE_BUFFER.set(buffer_receive).unwrap();
+        SEND_BUFFER.set(buffer_send).map_err(|e| {
+            error!("Failed to set send buffer: {e:?}");
+            ()
+        })?;
+        RECEIVE_BUFFER.set(buffer_receive).map_err(|e| {
+            error!("Failed to set receive buffer: {e:?}");
+            ()
+        })?;
 
         libspdm_register_device_io_func(
             context,

--- a/src/usb_i2c.rs
+++ b/src/usb_i2c.rs
@@ -377,26 +377,58 @@ pub fn register_device(
     let buffer_send = [0; SEND_RECEIVE_BUFFER_LEN];
     let buffer_receive = [0; SEND_RECEIVE_BUFFER_LEN];
 
-    let udev = usb_dev.expect("USB device path not specified");
+    let udev = usb_dev.ok_or_else(|| {
+        error!("USB device path not specified");
+        ()
+    })?;
 
     let port = serialport::new(&udev, usb_baud)
         .timeout(Duration::from_secs(30))
         .open()
-        .expect("Failed to open port");
+        .map_err(|e| {
+            error!("Failed to open port {:?}", e);
+            ()
+        })?;
 
     // Clear I/O buffers to drop any misc/lingering data
-    port.clear(serialport::ClearBuffer::All)
-        .expect("Failed to clear buffer for {udev}");
-    assert_eq!(port.bytes_to_read().unwrap(), 0);
-    assert_eq!(port.bytes_to_write().unwrap(), 0);
+    port.clear(serialport::ClearBuffer::All).map_err(|e| {
+        error!("Failed to clear buffer for {udev}: {e:?}");
+        ()
+    })?;
+    assert_eq!(
+        port.bytes_to_read().map_err(|e| {
+            error!("Failed to read bytes: {:?}", e);
+            ()
+        })?,
+        0
+    );
+    assert_eq!(
+        port.bytes_to_write().map_err(|e| {
+            error!("Failed to read bytes: {:?}", e);
+            ()
+        })?,
+        0
+    );
 
     info!("Serial Port {:} at {:} bits/s", &udev, usb_baud);
 
-    SERIAL_PORT.lock().unwrap().replace(port);
+    SERIAL_PORT
+        .lock()
+        .map_err(|e| {
+            error!("Failed to lock serial port: {e:?}");
+            ()
+        })?
+        .replace(port);
 
     unsafe {
-        SEND_BUFFER.set(buffer_send).unwrap();
-        RECEIVE_BUFFER.set(buffer_receive).unwrap();
+        SEND_BUFFER.set(buffer_send).map_err(|e| {
+            error!("Failed to set send buffer: {e:?}");
+            ()
+        })?;
+        RECEIVE_BUFFER.set(buffer_receive).map_err(|e| {
+            error!("Failed to set receive buffer: {e:?}");
+            ()
+        })?;
 
         let _ = MCTPCONTEXT.set(libmctp::MCTPSMBusContext::new(
             SOURCE_ID,


### PR DESCRIPTION
As we are moving towards a v1.0, let's try to not panic on trivial errors, instead log the error the propagate it up the call stack.

This does come at the cost of more verbose code, I _think_ that's justified when we need to debug, at least we can grep the error message instead of trying to figure out what failed.

Also add support to entering PCIe VID/DevIDs in hex format for the PCIe DOE transport layer. That is `0x` prefixed. We still accept base 10 as before as well.