### PR TITLE
pcie_ids: allow hex argument inputs

### DIFF
--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -8,6 +8,38 @@ use crate::*;
 
 /// # Summary
 ///
+/// Parses the string arguments that specifies the PCIe Vendor ID and Device ID.
+///
+/// # Parameter
+///
+/// * `vid`: specified as a hex string "0xCAF3" or as base 10 "1234".
+/// * `dev_id`: specified as a hex string "0xCAF3" or as base 10 "1234".
+///
+/// # Returns
+///
+/// On success, OK((vid, dev_id)) or Err(()) on failure to parse.
+pub fn parse_pcie_identifiers(vid: String, dev_id: String) -> Result<(u16, u16), ()> {
+    fn parse_identifier(id: String, id_type: &str) -> Result<u16, ()> {
+        let (id, base) = if id.starts_with("0x") {
+            (id.trim_start_matches("0x"), 16)
+        } else {
+            (id.as_str(), 10)
+        };
+
+        u16::from_str_radix(id, base).map_err(|e| {
+            error!("Invalid PCIe {id_type}: {:} - err {:?}", id, e);
+            ()
+        })
+    }
+
+    let vid = parse_identifier(vid, "vendor ID")?;
+    let dev_id = parse_identifier(dev_id, "device ID")?;
+
+    Ok((vid, dev_id))
+}
+
+/// # Summary
+///
 /// Parses the CLI argument for the SPDM version used by a responder.
 ///
 /// # Parameter

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,12 +41,12 @@ struct Args {
     doe_pci_cfg: bool,
 
     /// PCIe Identifier, Vendor ID of the SPDM supported device
-    #[arg(long, default_value_t = 0)]
-    pcie_vid: u16,
+    #[arg(long, default_value = "")]
+    pcie_vid: String,
 
     /// PCIe Identifier, Device ID of the SPDM supported device
-    #[arg(long, default_value_t = 0)]
-    pcie_devid: u16,
+    #[arg(long, default_value = "")]
+    pcie_devid: String,
 
     /// Use the Socket Server backend
     #[arg(long)]
@@ -309,9 +309,10 @@ fn main() -> Result<(), ()> {
     if cli.doe_pci_cfg {
         // Check that a device exists with provided vid/devid
         unsafe {
-            let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(cli.pcie_vid, cli.pcie_devid)?;
+            let (vid, dev_id) = cli_helpers::parse_pcie_identifiers(cli.pcie_vid, cli.pcie_devid)?;
+            let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(vid, dev_id)?;
             pci_cleanup(pacc);
-            doe_pci_cfg::register_device(cntx_ptr, cli.pcie_vid, cli.pcie_devid)?;
+            doe_pci_cfg::register_device(cntx_ptr, vid, dev_id)?;
         }
     } else if cli.socket_server {
         socket_server::register_device(cntx_ptr)?;


### PR DESCRIPTION
Allows the pcie vendor and device ids to be entered in either hex or base 10 format. This should maintain backwards compatibility also.