### PR TITLE
libspdm: spdm: Fixup info buffer pointer for hkdf_expand

### DIFF
--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -2334,7 +2334,7 @@ pub unsafe extern "C" fn libspdm_psk_master_secret_hkdf_expand(
         base_hash_algo,
         master_secret.as_mut_ptr(),
         hash_size,
-        &info as *const _ as *const u8,
+        info,
         info_size,
         out,
         out_size,


### PR DESCRIPTION
We were incorrectly passing the wrong address of `info` to `libspdm_hkdf_expand()`. We ended up passing a reference to info and casting it to the correct type.

Let's fix this up and just directly pass the pointer we were passed in the function arguments back to the libspdm `libspdm_hkdf_expand()` function.