### PR TITLE
Add support for sending explicit SPDM requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,26 @@ You can also run the libspdm tests by running tests on the socket server with:
 cargo run -- --socket-server tests
 ```
 
+### Issuing explicit requests
+
+`spdm-utils` can issue a user defined list of SPDM request(s). This is different
+from the `request <SPDM_REQ>` command in that, with `requests-only <SPDM_REQ_LIST>`
+a session is not established. It is the responsibility of the user to ensure,
+the SPDM requests are ordered in a specification compliant way. It is not checked
+by `spdm-utils` or `libspdm`. This shall be particularly useful when testing
+and developing an SPDM responder. It may also be useful to setup CI actions.
+
+Usage is as follows, as demonstrated over the socket model. Ensure you have an
+SPDM responder server socket running in responder mode prior to issuing this
+command.
+```
+$ ./target/debug/spdm_utils --socket-client requests-only GET_VERSION
+```
+or something a little more interesting!
+```
+$./target/debug/spdm_utils --socket-client requests-only GET_VERSION,GET_CAPABILITIES,NEGOTIATE_ALGORITHMS,GET_DIGESTS,GET_CERTIFICATE
+```
+
 ## Testing a real device
 
 You can run SPDM-Utils on the host to interact with a real DOE device. To do

--- a/src/request.rs
+++ b/src/request.rs
@@ -279,7 +279,11 @@ pub fn prepare_request(
 
                 let ret = libspdm_get_digest(
                     cntx_ptr,
-                    ptr::null_mut(),
+                    if session_info.session_id == 0 {
+                        ptr::null_mut()
+                    } else {
+                        &session_info.session_id as *const u32
+                    },
                     &mut slot_mask,
                     total_digest_buffer_ptr,
                 );
@@ -307,7 +311,11 @@ pub fn prepare_request(
 
                 let ret = libspdm_get_certificate(
                     cntx_ptr,
-                    &session_info.session_id,
+                    if session_info.session_id == 0 {
+                        ptr::null_mut()
+                    } else {
+                        &session_info.session_id as *const u32
+                    },
                     cert_slot_id,
                     &mut cert_chain_size,
                     cert_chain_ptr,
@@ -504,9 +512,15 @@ pub fn prepare_request(
             }
             RequestCode::EncapsulatedSendReceive { secure_msg } => {
                 let ret = if secure_msg {
-                    let session_id_ptr = &mut session_info.session_id as *mut u32;
                     // session_id is not NULL, it is a secured message
-                    libspdm_send_receive_encap_request(cntx_ptr, session_id_ptr)
+                    libspdm_send_receive_encap_request(
+                        cntx_ptr,
+                        if session_info.session_id == 0 {
+                            ptr::null_mut()
+                        } else {
+                            &session_info.session_id as *const u32
+                        },
+                    )
                 } else {
                     // session_id is NULL, it is a normal message
                     libspdm_send_receive_encap_request(cntx_ptr, ptr::null_mut())

--- a/src/request.rs
+++ b/src/request.rs
@@ -389,6 +389,16 @@ pub fn prepare_request(
                 }
             }
             RequestCode::GetVersion {} => {
+                let ret = libspdm_get_version(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue GetVersion request: {ret:x?}");
+                    return Err(ret);
+                }
+
                 let parameter = libspdm_data_parameter_t::new_connection(session_info.slot_id);
                 let mut spdm_version = spdm::SpdmVersionNumber(0);
                 let mut data_size: usize = core::mem::size_of::<u32>();
@@ -445,9 +455,24 @@ pub fn prepare_request(
                 spdm::get_measurements(cntx_ptr, session_info.slot_id)?;
             }
             RequestCode::GetCapabilities {} => {
+                let ret = libspdm_get_capabilities(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue GetCapabilities request: {ret:x?}");
+                    return Err(ret);
+                }
                 get_responder_capabilities(cntx_ptr);
             }
-            RequestCode::NegotiateAlgorithms {} => {}
+            RequestCode::NegotiateAlgorithms {} => {
+                let ret = libspdm_negotiate_algorithms(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue NegotiateAlgorithms request: {ret:x?}");
+                    return Err(ret);
+                }
+            }
             RequestCode::Heartbeat {} => {
                 let ret = libspdm_heartbeat(cntx_ptr, session_info.session_id);
                 if LibspdmReturnStatus::libspdm_status_is_error(ret) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::ptr;
 
 const LIBSPDM_MAX_CSR_SIZE: usize = 0x1000;
-
+const LIBSPDM_STATUS_INVALID_STATE_LOCAL: u32 = 0x80010003;
 /// # Summary
 /// Setup the capabilities of the requester
 ///
@@ -466,7 +466,9 @@ pub fn prepare_request(
                 let ret = libspdm_get_capabilities(
                     cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
                 );
-                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                if ret == LIBSPDM_STATUS_INVALID_STATE_LOCAL {
+                    warn!("GET_CAPABILITES was already issued");
+                } else if LibspdmReturnStatus::libspdm_status_is_error(ret) {
                     error!("Failed to issue GetCapabilities request: {ret:x?}");
                     return Err(ret);
                 }

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -63,21 +63,14 @@ pub fn setup_test_backend(cntx: *mut c_void) -> Result<SpdmSessionInfo, u32> {
     unsafe {
         spdm::initialise_connection(cntx, slot_id).unwrap();
     }
-    let mut session_info = unsafe { spdm::start_session(cntx, slot_id, false).unwrap() };
+    let session_info = unsafe { spdm::start_session(cntx, slot_id, false).unwrap() };
     // Print out the negotiated algorithms
     unsafe {
         spdm::get_negotiated_algos(cntx, slot_id).unwrap();
     }
 
-    info!("[{slot_id}] Start RequestCode::GetCapabilities");
-    request::prepare_request(
-        cntx,
-        RequestCode::GetCapabilities {},
-        slot_id,
-        None,
-        &mut session_info,
-    )?;
-    info!(" RequestCode::GetCapabilities ... [OK]");
+    info!("[{slot_id}] Listing Responder Capabilities");
+    unsafe { request::get_responder_capabilities(cntx) };
 
     Ok(session_info)
 }


### PR DESCRIPTION
Currently,  `spdm-utils`  will initialise a connection (which consists of GET_VERSION/CAPABILITIES/NEGOTIATE_ALGOS ... etc) and then sens the user specified SPDM request (`requst <CMD>`). However, this may not be desired, if a user intends to send only the specified command. This could particularly be useful for debugging/development/testing & CI.

This patch adds supports to a new command `requests-only` which will issue only the commands listed. See README for usage. 