### PR TITLE
spdm-requests: make sure we alway issue requests

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -389,6 +389,16 @@ pub fn prepare_request(
                 }
             }
             RequestCode::GetVersion {} => {
+                let ret = libspdm_get_version(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                    std::ptr::null_mut(),
+                    std::ptr::null_mut(),
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue GetVersion request: {ret:x?}");
+                    return Err(ret);
+                }
+
                 let parameter = libspdm_data_parameter_t::new_connection(session_info.slot_id);
                 let mut spdm_version = spdm::SpdmVersionNumber(0);
                 let mut data_size: usize = core::mem::size_of::<u32>();
@@ -445,9 +455,24 @@ pub fn prepare_request(
                 spdm::get_measurements(cntx_ptr, session_info.slot_id)?;
             }
             RequestCode::GetCapabilities {} => {
+                let ret = libspdm_get_capabilities(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue GetCapabilities request: {ret:x?}");
+                    return Err(ret);
+                }
                 get_responder_capabilities(cntx_ptr);
             }
-            RequestCode::NegotiateAlgorithms {} => {}
+            RequestCode::NegotiateAlgorithms {} => {
+                let ret = libspdm_negotiate_algorithms(
+                    cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
+                );
+                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                    error!("Failed to issue NegotiateAlgorithms request: {ret:x?}");
+                    return Err(ret);
+                }
+            }
             RequestCode::Heartbeat {} => {
                 let ret = libspdm_heartbeat(cntx_ptr, session_info.session_id);
                 if LibspdmReturnStatus::libspdm_status_is_error(ret) {

--- a/src/request.rs
+++ b/src/request.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use std::ptr;
 
 const LIBSPDM_MAX_CSR_SIZE: usize = 0x1000;
-
+const LIBSPDM_STATUS_INVALID_STATE_LOCAL: u32 = 0x80010003;
 /// # Summary
 /// Setup the capabilities of the requester
 ///
@@ -458,7 +458,9 @@ pub fn prepare_request(
                 let ret = libspdm_get_capabilities(
                     cntx_ptr as *mut libspdm::libspdm_rs::libspdm_context_t,
                 );
-                if LibspdmReturnStatus::libspdm_status_is_error(ret) {
+                if ret == LIBSPDM_STATUS_INVALID_STATE_LOCAL {
+                    warn!("GET_CAPABILITES was already issued");
+                } else if LibspdmReturnStatus::libspdm_status_is_error(ret) {
                     error!("Failed to issue GetCapabilities request: {ret:x?}");
                     return Err(ret);
                 }

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -63,21 +63,14 @@ pub fn setup_test_backend(cntx: *mut c_void) -> Result<SpdmSessionInfo, u32> {
     unsafe {
         spdm::initialise_connection(cntx, slot_id).unwrap();
     }
-    let mut session_info = unsafe { spdm::start_session(cntx, slot_id, false).unwrap() };
+    let session_info = unsafe { spdm::start_session(cntx, slot_id, false).unwrap() };
     // Print out the negotiated algorithms
     unsafe {
         spdm::get_negotiated_algos(cntx, slot_id).unwrap();
     }
 
-    info!("[{slot_id}] Start RequestCode::GetCapabilities");
-    request::prepare_request(
-        cntx,
-        RequestCode::GetCapabilities {},
-        slot_id,
-        None,
-        &mut session_info,
-    )?;
-    info!(" RequestCode::GetCapabilities ... [OK]");
+    info!("[{slot_id}] Listing Responder Capabilities");
+    unsafe { request::get_responder_capabilities(cntx) };
 
     Ok(session_info)
 }


### PR DESCRIPTION
Instead of *just* extracting information from the session, ensure we issue the GET_VERSION/GET_CAPABILITIES requests.

Also support NEGOTIATE_ALGORITHMS  request.

Split from: https://github.com/westerndigitalcorporation/spdm-utils/pull/97