### PR TITLE
permissions: check effective user id at start

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ dependencies = [
  "memmap2",
  "minicbor",
  "minicbor-derive",
+ "nix 0.29.0",
  "once_cell",
  "serialport",
  "sha2",
@@ -408,6 +409,12 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clang-sys"
@@ -1047,6 +1054,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,7 +1329,7 @@ dependencies = [
  "io-kit-sys",
  "libudev",
  "mach2",
- "nix",
+ "nix 0.26.4",
  "regex",
  "scopeguard",
  "unescaper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 default = ["std"]
 
 no_std = []
-std = ["clap", "memmap2", "once_cell", "sha2", "env_logger", "serialport", "lazy_static", "colored", "which", "asn1-rs", "x509-parser", "minicbor", "minicbor-derive", "async-std", "futures"]
+std = ["clap", "memmap2", "once_cell", "sha2", "env_logger", "serialport", "lazy_static", "colored", "which", "asn1-rs", "x509-parser", "minicbor", "minicbor-derive", "async-std", "futures", "nix"]
 
 [lib]
 name = "libspdm"
@@ -43,5 +43,6 @@ minicbor = { git = "https://gitlab.com/twittner/minicbor.git", features = ["half
 minicbor-derive = { git = "https://gitlab.com/twittner/minicbor.git", features = ["alloc", "std"], optional = true }
 async-std = { version = "1.12", features = ["attributes"], optional = true }
 futures = { version = "0.3", optional = true }
+nix = {version = "0.29.0", features = ["user"], optional = true }
 
 libmctp = { git = "https://github.com/westerndigitalcorporation/libmctp.git" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use async_std::task;
 use clap::{Parser, Subcommand};
 use futures::future::join_all;
 use libspdm::libspdm_rs::*;
+use nix::unistd::geteuid;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fs::File;
 use std::fs::OpenOptions;
@@ -322,6 +323,11 @@ async fn main() -> Result<(), ()> {
 
     if count > 1 {
         error!("Only a single backend can be used");
+        return Err(());
+    }
+
+    if (cli.doe_pci_cfg || cli.usb_i2c) && u32::from(geteuid()) != 0 {
+        error!("This transport operation requires root privileges");
         return Err(());
     }
 


### PR DESCRIPTION
Check that for DOE/USB_I2C, that `spdm-utils` was started with root privileges. Otherwise, print an error.