### PR TITLE
manifest: BER encode the OID

### DIFF
--- a/manifest/manifest.in.cbor
+++ b/manifest/manifest.in.cbor
@@ -7,7 +7,7 @@
         / environment-map / {
           / class / 0: {
             / class-id / 0:
-              / tagged-oid-type / 111(h'3170332E362E312E342E312E352E32310037'), / 1.3.6.1.4.1.5127 /
+              / tagged-oid-type / 111(h'06072B06010401A807'), / 1.3.6.1.4.1.5127 /
               / vendor / 1: "Western Digital Test"
           }
         },


### PR DESCRIPTION
This patch converts the measurement OID to be BER encoded.

I used the following diff to generate the DER encoded data

```diff
diff --git a/src/main.rs b/src/main.rs
index 181ca0f..077ecc3 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@
 //! (which is generated from here) or the README
 //!

+use asn1_rs::oid;
+use asn1_rs::ToDer;
 use async_std::task;
 use clap::{Parser, Subcommand};
 use futures::future::join_all;
@@ -629,6 +631,10 @@ fn init_logger() {
 #[async_std::main]
 async fn main() -> Result<(), ()> {
     init_logger();
+
+    let oid = oid!(1.3.6.1.4.1.5127);
+    panic!("OID: {:x?}", oid.to_der_vec());
+
     let cli = Args::parse();

     let cntx_ptr = spdm::initialise_spdm_context();
```

As [DER is a subset of BER](https://github.com/openssl/openssl/issues/7751#issuecomment-443950588) we can use the DER output directly.