### PR TITLE
certs: Split the requester and responder leaf cert extensions

### DIFF
--- a/certs/alias/openssl.cnf
+++ b/certs/alias/openssl.cnf
@@ -28,13 +28,23 @@ id-spdm-cert-oid = SEQUENCE:alias_ca_spdm_cert_mutable_oid
 [ alias_ca_spdm_cert_mutable_oid ]
 id-DMTF-mutable-certificate = OID:1.3.6.1.4.1.412.274.5
 
-[ leaf ]
+[ leaf_requester ]
 basicConstraints = critical,CA:false
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 subjectKeyIdentifier = hash
 subjectAltName = otherName:2.23.147;UTF8:Vendor=1b36:Device=0010:CC=010802:REV=02:SSVID=1af4:SSID=1100
-# Add SPDM Responder Authentication { id-DMTF-spdm 3 }, SPDM Requester Authentication { id-DMTF-spdm 4 }, tcg-dice-kp-eca, tcg-dice-kp-identityLoc, tcg-dice-kp-attestLoc, tcg-dice-kp-assertLoc
-extendedKeyUsage = critical, serverAuth, clientAuth, OCSPSigning, 1.3.6.1.4.1.412.274.3, 1.3.6.1.4.1.412.274.4, 2.23.133.5.4.100.12, 2.23.133.5.4.100.7, 2.23.133.5.4.100.9, 2.23.133.5.4.100.11
+# Add SPDM Requester Authentication { id-DMTF-spdm 4 }, tcg-dice-kp-eca, tcg-dice-kp-identityLoc, tcg-dice-kp-attestLoc, tcg-dice-kp-assertLoc
+extendedKeyUsage = critical, serverAuth, clientAuth, OCSPSigning, 1.3.6.1.4.1.412.274.4, 2.23.133.5.4.100.12, 2.23.133.5.4.100.7, 2.23.133.5.4.100.9, 2.23.133.5.4.100.11
+
+1.3.6.1.4.1.412.274.6 = ASN1:SEQUENCE:leaf_spdm_cert_oids # id-spdm-cert-oids
+
+[ leaf_responder ]
+basicConstraints = critical,CA:false
+keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+subjectKeyIdentifier = hash
+subjectAltName = otherName:2.23.147;UTF8:Vendor=1b36:Device=0010:CC=010802:REV=02:SSVID=1af4:SSID=1100
+# Add SPDM Responder Authentication { id-DMTF-spdm 3 }, tcg-dice-kp-eca, tcg-dice-kp-identityLoc, tcg-dice-kp-attestLoc, tcg-dice-kp-assertLoc
+extendedKeyUsage = critical, serverAuth, clientAuth, OCSPSigning, 1.3.6.1.4.1.412.274.3, 2.23.133.5.4.100.12, 2.23.133.5.4.100.7, 2.23.133.5.4.100.9, 2.23.133.5.4.100.11
 
 1.3.6.1.4.1.412.274.6 = ASN1:SEQUENCE:leaf_spdm_cert_oids # id-spdm-cert-oids
 

--- a/certs/setup_certs.sh
+++ b/certs/setup_certs.sh
@@ -21,8 +21,8 @@ openssl x509 -req -in alias.req -out alias.cert -CA device.der -sha384 -days 365
 cp ../../slot0/end* ./
 
 # Sign the CSRs
-openssl x509 -req -in end_requester.req -out end_requester.cert -CA alias.cert -CAkey alias.key -sha384 -days 3650 -set_serial 4 -extensions leaf -extfile ../openssl.cnf
-openssl x509 -req -in end_responder.req -out end_responder.cert -CA alias.cert -CAkey alias.key -sha384 -days 3650 -set_serial 5 -extensions leaf -extfile ../openssl.cnf
+openssl x509 -req -in end_requester.req -out end_requester.cert -CA alias.cert -CAkey alias.key -sha384 -days 3650 -set_serial 4 -extensions leaf_requester -extfile ../openssl.cnf
+openssl x509 -req -in end_responder.req -out end_responder.cert -CA alias.cert -CAkey alias.key -sha384 -days 3650 -set_serial 5 -extensions leaf_responder -extfile ../openssl.cnf
 
 # Generate der files
 openssl asn1parse -in alias.cert -out alias.cert.der


### PR DESCRIPTION
Split the requester and responder leaf certificate extensions so we can have a single SPDM Responder/Requester Authentication OID in each one.