### PR TITLE
manifest/manifest.in.cbor: Fixup BER encoding

### DIFF
--- a/manifest/manifest.in.cbor
+++ b/manifest/manifest.in.cbor
@@ -7,7 +7,7 @@
         / environment-map / {
           / class / 0: {
             / class-id / 0:
-              / tagged-oid-type / 111(h'06072B06010401A807'), / 1.3.6.1.4.1.5127 /
+              / tagged-oid-type / 111(h'2B06010401A807'), / 1.3.6.1.4.1.5127 /
               / vendor / 1: "Western Digital Test"
           }
         },


### PR DESCRIPTION
This fixes 0ec1dca5b60e "manifest: BER encode the OID" by using the `into_cow()` function to get the output instead of the original `to_der_vec()`.

The new diff to generate the OID is

```diff
diff --git a/src/main.rs b/src/main.rs
index 181ca0f..fd85724 100644
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@
 //! (which is generated from here) or the README
 //!

+use asn1_rs::oid;
+use asn1_rs::ToDer;
 use async_std::task;
 use clap::{Parser, Subcommand};
 use futures::future::join_all;
@@ -629,6 +631,10 @@ fn init_logger() {
 #[async_std::main]
 async fn main() -> Result<(), ()> {
     init_logger();
+
+    let oid = oid!(1.3.6 .1 .4 .1 .5127);
+    panic!("OID: {:x?}", oid.into_cow());
+
     let cli = Args::parse();

     let cntx_ptr = spdm::initialise_spdm_context();
```

Fixes: 0ec1dca5b60e "manifest: BER encode the OID"