### PR TITLE
socket-server: optional server keep alive feature

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,10 @@ struct Args {
     #[arg(long)]
     socket_server: bool,
 
+    /// If the client drops, keep the server alive
+    #[arg(long)]
+    server_persist: bool,
+
     /// Use the usb-i2c transport layer (for mctp)
     #[arg(long)]
     usb_i2c: bool,
@@ -670,7 +674,7 @@ async fn main() -> Result<(), ()> {
             doe_pci_cfg::register_device(cntx_ptr, vid, dev_id)?;
         }
     } else if cli.socket_server {
-        socket_server::register_device(cntx_ptr)?;
+        socket_server::register_device(cntx_ptr, cli.server_persist)?;
     } else if cli.socket_client {
         socket_client::register_device(cntx_ptr)?;
     } else if cli.usb_i2c {


### PR DESCRIPTION
For convienience, the `--server-persist` option can now be given to an instance of the socket-server, such that it keeps alive after the client drops. The user can spin up another client without having to restart the server.