### PR TITLE
build.rs: warn if cbordiag tools are not found 

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -157,9 +157,9 @@ fn main() {
                     file.write_all(&pretty_format)
                         .expect("failed to write to `manifest.pretty`");
                 }
-                Err(e) => panic!("Ruby script {script} not found : error {}", e),
+                Err(e) => {println!("\x1b[33mcargo:warning=Ruby script {script} not found : error {}\x1b[0m", e)},
             }
         }
-        Err(e) => panic!("Ruby script {script} not found : error {}", e),
+        Err(e) => println!("\x1b[33mcargo:warning=Ruby script {script} not found : error {}\nSkipping fresh manifest generation\x1b[0m", e),
     }
 }


### PR DESCRIPTION
Instead of panicking at built time, just warn about the cbor tools not
being found. At run-time, `spdm-utils` will return an error when
attempting decode a cbor encoded manifest from a responder.

This should not affect a responder as we already have pre-generated
manifests checked in the `manifests/` directory.

The primary motivation for this is to allow the `Buildroot` package to be upstream friendly.