### PR TITLE
pci_doe: tests: add a status::busy check

### DIFF
--- a/src/doe_pci_cfg.rs
+++ b/src/doe_pci_cfg.rs
@@ -689,6 +689,13 @@ pub unsafe fn test_discovery_all() -> Result<(), ()> {
             discovery_packet.dw0 |= (DOE_VERSION as u32) << DOE_REQUEST_VERSION_SHIFT;
         }
 
+        doe_wait_not_busy(device, doe_offset).map_err(|e| match e {
+            DoeStatus::DoeStatusErr => {
+                doe_issue_abort(device, doe_offset, true);
+                ()
+            }
+        })?;
+
         info!("Discovery Request: {}", discovery_packet);
 
         for data in discovery_packet.as_array().iter() {


### PR DESCRIPTION
During the discovery all tests, ensure we wait for the device to clear `STATUS::BUSY` before writing to the mailbox and setting DOR.