### PR TITLE
doe_pci_cfg: add doe auto suggest support

### DIFF
--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -4,7 +4,55 @@
 
 //! Contains helper functions used in parsing the CLI arguments
 
+use crate::doe_pci_cfg::PcieDevInfo;
 use crate::*;
+use std::io;
+
+/// # Summary
+///
+/// Print all of the devices in `doe_devices` and prompt the user to select a
+/// device by index (0's based). This index directly maps to an object in
+/// `doe_devices`
+///
+/// # Parameter
+///
+/// * `doe_devices`: A vector of PCIe devices that support DoE
+///
+/// # Returns
+///
+/// On success, OK(index) where the index maps to a device in `doe_device`
+/// On any failure, returns an error
+pub fn pcie_devices_user_select(doe_devices: &Vec<PcieDevInfo>) -> Result<usize, ()> {
+    let mut index = 0;
+    let num_devs = doe_devices.len();
+
+    info!("Listing devices with PCIe DoE Support on this system");
+    for dev in doe_devices {
+        info!("index:{} - {}", index, dev.name);
+        index += 1;
+    }
+    info!("Enter device index number to use");
+    let mut usr_in = String::new();
+    io::stdin().read_line(&mut usr_in).map_err(|e| {
+        error!("Failed to read index input: {e}");
+        ()
+    })?;
+    let usr_in = usr_in.trim();
+
+    match usr_in.parse::<usize>() {
+        Ok(index) => {
+            if index as usize >= num_devs {
+                error!("Invalid device index");
+                return Err(());
+            }
+            return Ok(index);
+        }
+        Err(_) => {
+            error!("Unexpected input: {}", usr_in);
+            return Err(());
+        }
+    }
+}
 
 /// # Summary
 ///


### PR DESCRIPTION
If a device id and vendor id is not specified by user, scan the PCIe bus for devices that support DoE capability. Then suggest a list of options for the user to choose from. `spdm-utils` will read the specified device index from stdin then fetch the corresponding device and vendor ids.


Usage:

```
twilfred@fedora ~/spdm-utils (master) [SIGINT]> sudo ./target/debug/spdm_utils --doe-pci-cfg --no-session request get-version
[2025-01-09T03:44:38Z DEBUG spdm_utils] Logger initialisation [OK]
[2025-01-09T03:44:38Z DEBUG spdm_utils::doe_pci_cfg] Found device: 01:00.0 Non-Volatile memory controller [0108]: Western Digital Device [1b96:0001]
[2025-01-09T03:44:38Z INFO  spdm_utils::cli_helpers] Listing devices with PCIe DoE Support on this system
[2025-01-09T03:44:38Z INFO  spdm_utils::cli_helpers] index:0 - 01:00.0 Non-Volatile memory controller [0108]: Western Digital Device [1b96:0001]
[2025-01-09T03:44:38Z INFO  spdm_utils::cli_helpers] Enter device index number to use
0
[2025-01-09T03:44:42Z DEBUG spdm_utils::cli_helpers] Specified Algos: 128
[2025-01-09T03:44:42Z DEBUG spdm_utils::cli_helpers] Specified hashing Algos: 2
[2025-01-09T03:44:42Z DEBUG spdm_utils::cli_helpers] Specified dhe groups: 48
[2025-01-09T03:44:42Z DEBUG spdm_utils::cli_helpers] Specified aead cipher suites: 2
libspdm_send_spdm_request[0] msg SPDM_GET_VERSION(0x84), size (0x4): 
0000: 10 84 00 00 
[2025-01-09T03:44:42Z INFO  spdm_utils::doe_pci_cfg] Sending message [1, 0, 1, 0, 3, 0, 0, 0, 10, 84, 0, 0]
[2025-01-09T03:44:42Z INFO  spdm_utils::doe_pci_cfg] Sent!
    
[2025-01-09T03:44:42Z INFO  spdm_utils::doe_pci_cfg] Receiving message
[2025-01-09T03:44:42Z INFO  spdm_utils::doe_pci_cfg] Received: [1, 0, 1, 0, 4, 0, 0, 0, 10, 4, 0, 0, 0, 1, 0, 12]
libspdm_receive_spdm_response[0] msg SPDM_VERSION(0x4), size (0x8): 
0000: 10 04 00 00 00 01 00 12 
[2025-01-09T03:44:42Z INFO  spdm_utils::request] Responder SpdmVersion: 1.2.0.0
```


Does not break backwards compatibility, we can still do:

```
twilfred@fedora ~/spdm-utils (master)> sudo ./target/debug/spdm_utils --pcie-vid 0x1B96 --pcie-devid 0x1 --doe-pci-cfg --no-session request get-version
[2025-01-09T03:45:20Z DEBUG spdm_utils] Logger initialisation [OK]
[2025-01-09T03:45:20Z DEBUG spdm_utils::cli_helpers] Specified Algos: 128
[2025-01-09T03:45:20Z DEBUG spdm_utils::cli_helpers] Specified hashing Algos: 2
[2025-01-09T03:45:20Z DEBUG spdm_utils::cli_helpers] Specified dhe groups: 48
[2025-01-09T03:45:20Z DEBUG spdm_utils::cli_helpers] Specified aead cipher suites: 2
libspdm_send_spdm_request[0] msg SPDM_GET_VERSION(0x84), size (0x4): 
0000: 10 84 00 00 
[2025-01-09T03:45:20Z INFO  spdm_utils::doe_pci_cfg] Sending message [1, 0, 1, 0, 3, 0, 0, 0, 10, 84, 0, 0]
[2025-01-09T03:45:20Z INFO  spdm_utils::doe_pci_cfg] Sent!
    
[2025-01-09T03:45:20Z INFO  spdm_utils::doe_pci_cfg] Receiving message
[2025-01-09T03:45:20Z INFO  spdm_utils::doe_pci_cfg] Received: [1, 0, 1, 0, 4, 0, 0, 0, 10, 4, 0, 0, 0, 1, 0, 12]
libspdm_receive_spdm_response[0] msg SPDM_VERSION(0x4), size (0x8): 
0000: 10 04 00 00 00 01 00 12 
[2025-01-09T03:45:20Z INFO  spdm_utils::request] Responder SpdmVersion: 1.2.0.0
```