### PR TITLE
libspdm: spdm: Set DataTransferSize to MaxSPDMmsgSize

### DIFF
--- a/src/io_buffers.rs
+++ b/src/io_buffers.rs
@@ -6,12 +6,12 @@ static mut RECEIVE_BUFFER: OnceCell<Vec<u8>> = OnceCell::new();
 
 pub fn libspdm_setup_io_buffers(
     context: *mut c_void,
-    send_recv_len: usize,
-    libsdpm_buff_len: usize,
+    send_len: usize,
+    recv_len: usize,
 ) -> Result<(), ()> {
     let result = std::panic::catch_unwind(|| {
-        let buffer_send = vec![0; send_recv_len];
-        let buffer_receive = vec![0; send_recv_len];
+        let buffer_send = vec![0; send_len];
+        let buffer_receive = vec![0; recv_len];
         (buffer_send, buffer_receive)
     });
 
@@ -31,8 +31,8 @@ pub fn libspdm_setup_io_buffers(
             unsafe {
                 libspdm::libspdm_rs::libspdm_register_device_buffer_func(
                     context,
-                    libsdpm_buff_len as u32,
-                    libsdpm_buff_len as u32,
+                    send_len as u32,
+                    recv_len as u32,
                     Some(acquire_sender_buffer),
                     Some(release_sender_buffer),
                     Some(acquire_receiver_buffer),

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -487,7 +487,8 @@ pub unsafe fn setup_transport_layer(
         TransportLayer::Doe => {
             libspdm_register_transport_layer_func(
                 context,
-                libspdm_max_spdm_msg_size,
+                libspdm_max_spdm_msg_size
+                    - (LIBSPDM_PCI_DOE_TRANSPORT_HEADER_SIZE + LIBSPDM_PCI_DOE_TRANSPORT_TAIL_SIZE),
                 LIBSPDM_PCI_DOE_TRANSPORT_HEADER_SIZE,
                 LIBSPDM_PCI_DOE_TRANSPORT_TAIL_SIZE,
                 Some(libspdm_transport_pci_doe_encode_message),
@@ -497,27 +498,14 @@ pub unsafe fn setup_transport_layer(
         TransportLayer::Mctp => {
             libspdm_register_transport_layer_func(
                 context,
-                libspdm_max_spdm_msg_size,
+                libspdm_max_spdm_msg_size
+                    - (LIBSPDM_MCTP_TRANSPORT_HEADER_SIZE + LIBSPDM_MCTP_TRANSPORT_TAIL_SIZE),
                 LIBSPDM_MCTP_TRANSPORT_HEADER_SIZE,
                 LIBSPDM_MCTP_TRANSPORT_TAIL_SIZE,
                 Some(libspdm_transport_mctp_encode_message),
                 Some(libspdm_transport_mctp_decode_message),
             );
         }
-    }
-
-    let parameter = libspdm_rs::libspdm_data_parameter_t::new_connection(0);
-    let mut data: u32 = libspdm_max_spdm_msg_size;
-    let data_ptr = &mut data as *mut _ as *mut c_void;
-    if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
-        context,
-        libspdm_rs::libspdm_data_type_t_LIBSPDM_DATA_CAPABILITY_MAX_SPDM_MSG_SIZE,
-        &parameter as *const libspdm_rs::libspdm_data_parameter_t,
-        data_ptr,
-        core::mem::size_of::<u32>(),
-    )) {
-        error!("Unable to set data");
-        return Err(());
     }
 
     let libspdm_scratch_buffer_size = libspdm_get_sizeof_required_scratch_buffer(context);


### PR DESCRIPTION
Some of the unit tests disable `CHUNK_CAP` support, in which case `DataTransferSize` must equal `MaxSPDMmsgSize`. 

To ensure the tests run correctly let's set `DataTransferSize` to `MaxSPDMmsgSize`