### PR TITLE
rust24: fixup static_mut_refs warning and improve generaly safety

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,6 +13,7 @@ dependencies = [
  "colored",
  "env_logger",
  "futures",
+ "inquire",
  "lazy_static",
  "libmctp",
  "log",
@@ -72,7 +73,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -83,7 +84,7 @@ checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
  "once_cell",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -240,7 +241,7 @@ dependencies = [
  "rustix",
  "slab",
  "tracing",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -366,6 +367,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "cexpr"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,7 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -492,6 +499,31 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -560,6 +592,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,7 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -730,6 +768,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +841,7 @@ version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -793,6 +849,23 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.8.0",
+ "crossterm",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width",
+]
 
 [[package]]
 name = "io-kit-sys"
@@ -812,7 +885,7 @@ checksum = "e19b23d53f35ce9f56aebc7d1bb4e6ac1e9c0db7ac85c8d1760c04379edced37"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -874,7 +947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -912,6 +985,16 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -972,6 +1055,27 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nix"
@@ -1062,6 +1166,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1102,7 +1229,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1137,6 +1264,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+dependencies = [
+ "bitflags 2.8.0",
 ]
 
 [[package]]
@@ -1193,7 +1329,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1265,6 +1401,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1272,6 +1438,12 @@ checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "smbus-pec"
@@ -1363,6 +1535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "time"
 version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,6 +1613,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1453,6 +1647,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1569,7 +1769,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1580,11 +1780,35 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -1593,15 +1817,21 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -1611,9 +1841,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1629,9 +1871,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1641,9 +1895,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,3 +73,4 @@ async-std = { version = "1.12", features = ["attributes"], optional = true }
 futures = { version = "0.3", optional = true }
 nix = { version = "0.29.0", features = ["user"], optional = true }
 libmctp = { version = "0.2" }
+inquire = "0.7.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ std = [
     "async-std",
     "futures",
     "nix",
+    "inquire",
 ]
 
 [lib]
@@ -73,4 +74,4 @@ async-std = { version = "1.12", features = ["attributes"], optional = true }
 futures = { version = "0.3", optional = true }
 nix = { version = "0.29.0", features = ["user"], optional = true }
 libmctp = { version = "0.2" }
-inquire = "0.7.5"
+inquire = { version = "0.7.5", optional = true}

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -6,13 +6,12 @@
 
 use crate::doe_pci_cfg::PcieDevInfo;
 use crate::*;
-use std::io;
+use inquire::Select;
 
 /// # Summary
 ///
 /// Print all of the devices in `doe_devices` and prompt the user to select a
-/// device by index (0's based). This index directly maps to an object in
-/// `doe_devices`
+/// device.
 ///
 /// # Parameter
 ///
@@ -23,35 +22,19 @@ use std::io;
 /// On success, OK(index) where the index maps to a device in `doe_device`
 /// On any failure, returns an error
 pub fn pcie_devices_user_select(doe_devices: &Vec<PcieDevInfo>) -> Result<usize, ()> {
-    let mut index = 0;
-    let num_devs = doe_devices.len();
-
-    info!("Listing devices with PCIe DoE Support on this system");
-    for dev in doe_devices {
-        info!("index:{} - {}", index, dev.name);
-        index += 1;
-    }
-    info!("Enter device index number to use");
-    let mut usr_in = String::new();
-    io::stdin().read_line(&mut usr_in).map_err(|e| {
-        error!("Failed to read index input: {e}");
-        ()
-    })?;
-    let usr_in = usr_in.trim();
-
-    match usr_in.parse::<usize>() {
-        Ok(index) => {
-            if index as usize >= num_devs {
-                error!("Invalid device index");
-                return Err(());
+    let choice = Select::new("Select a device to use:\n", doe_devices.to_vec()).prompt();
+    match choice {
+        Ok(choice) => {
+            if let Some(index) = doe_devices.iter().position(|x| *x == choice) {
+                return Ok(index);
             }
-            return Ok(index);
         }
-        Err(_) => {
-            error!("Unexpected input: {}", usr_in);
+        Err(why) => {
+            error!("Unexpected error: {:?}", why);
             return Err(());
         }
     }
+    unreachable!();
 }
 
 /// # Summary

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -22,7 +22,7 @@ use inquire::Select;
 /// On success, OK(index) where the index maps to a device in `doe_device`
 /// On any failure, returns an error
 pub fn pcie_devices_user_select(doe_devices: &Vec<PcieDevInfo>) -> Result<usize, ()> {
-    let choice = Select::new("Select a device to use:\n", doe_devices.to_vec()).prompt();
+    let choice = Select::new("Select a PCIe DoE compatible device:", doe_devices.to_vec()).prompt();
     match choice {
         Ok(choice) => {
             if let Some(index) = doe_devices.iter().position(|x| *x == choice) {

--- a/src/doe_pci_cfg.rs
+++ b/src/doe_pci_cfg.rs
@@ -223,11 +223,17 @@ pub fn register_device(context: *mut c_void, pcie_vid: u16, pcie_devid: u16) -> 
     Ok(())
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct PcieDevInfo {
     pub name: String,
     pub vendor_id: u16,
     pub device_id: u16,
+}
+
+impl fmt::Display for PcieDevInfo {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.name)
+    }
 }
 
 /// # Summary

--- a/src/main.rs
+++ b/src/main.rs
@@ -607,7 +607,7 @@ fn parse_request_codes(s: &str) -> Result<Vec<RequestCode>, String> {
 /// Default to always log style if LOG_STYLE environment variable is not set
 fn init_logger() {
     let env = Env::default()
-        .filter_or("LOG_LEVEL", "trace")
+        .filter_or("LOG_LEVEL", "debug")
         .write_style_or("LOG_STYLE", "always");
 
     env_logger::init_from_env(env);

--- a/src/socket_server.rs
+++ b/src/socket_server.rs
@@ -12,16 +12,17 @@
 use crate::*;
 use core::ffi::c_void;
 use libspdm::spdm::LIBSPDM_MAX_SPDM_MSG_SIZE;
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 use std::fs;
 use std::io::{Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::Path;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::sync::Mutex;
 use std::time::Duration;
 
 const SEND_RECEIVE_BUFFER_LEN: usize = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
-static mut CLIENT_CONNECTION: OnceCell<UnixStream> = OnceCell::new();
+static CLIENT_CONNECTION: Lazy<Mutex<Option<UnixStream>>> = Lazy::new(|| Mutex::new(None));
 static mut SERVER_PERSIST: bool = false;
 
 /// # Summary
@@ -52,24 +53,28 @@ unsafe extern "C" fn sserver_send_message(
     message_ptr: *const c_void,
     timeout: u64,
 ) -> u32 {
-    let mut stream = CLIENT_CONNECTION.take().unwrap();
-    let message = message_ptr as *const u8;
-    let msg_buf = unsafe { from_raw_parts(message, message_size) };
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let message = message_ptr as *const u8;
+            let msg_buf = unsafe { from_raw_parts(message, message_size) };
 
-    if timeout == 0 {
-        stream
-            .set_write_timeout(None)
-            .expect("Couldn't set write timeout");
-    } else {
-        stream
-            .set_write_timeout(Some(Duration::from_micros(timeout)))
-            .expect("Couldn't set write timeout");
+            if timeout == 0 {
+                stream
+                    .set_write_timeout(None)
+                    .expect("Couldn't set write timeout");
+            } else {
+                stream
+                    .set_write_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set write timeout");
+            }
+
+            stream.write_all(msg_buf).unwrap();
+            stream.flush().unwrap();
+        }
+        None => {
+            unreachable!("Client connection lost");
+        }
     }
-
-    stream.write_all(msg_buf).unwrap();
-    stream.flush().unwrap();
-    CLIENT_CONNECTION.set(stream).unwrap();
-
     0
 }
 
@@ -101,42 +106,51 @@ unsafe extern "C" fn sserver_receive_message(
     msg_buf_ptr: *mut *mut c_void,
     timeout: u64,
 ) -> u32 {
-    let mut stream = CLIENT_CONNECTION.take().unwrap();
-    let message = *msg_buf_ptr as *mut u8;
-    let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+    let mut server_reset = false;
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let message = *msg_buf_ptr as *mut u8;
+            let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
 
-    if timeout == 0 {
-        stream
-            .set_read_timeout(None)
-            .expect("Couldn't set read timeout");
-    } else {
-        stream
-            .set_read_timeout(Some(Duration::from_micros(timeout)))
-            .expect("Couldn't set read timeout");
-    }
+            if timeout == 0 {
+                stream
+                    .set_read_timeout(None)
+                    .expect("Couldn't set read timeout");
+            } else {
+                stream
+                    .set_read_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set read timeout");
+            }
 
-    let mut read_len = stream.read(msg_buf);
-    while read_len.is_err() {
-        read_len = stream.read(msg_buf);
-    }
-    let read_len = read_len.unwrap();
+            let mut read_len = stream.read(msg_buf);
+            while read_len.is_err() {
+                read_len = stream.read(msg_buf);
+            }
+            let read_len = read_len.unwrap();
 
-    if read_len == 0 {
-        // when read() return 0, the two likely cases are:
-        // 1. socket shut down correctly
-        // 2. reader has reached its “end of file” and will likely no longer be
-        //    able to produce bytes
-        warn!("Connection dropped to client, exiting...");
-        if !SERVER_PERSIST {
-            std::process::exit(0);
+            if read_len == 0 {
+                // when read() return 0, the two likely cases are:
+                // 1. socket shut down correctly
+                // 2. reader has reached its “end of file” and will likely no longer be
+                //    able to produce bytes
+                warn!("Connection dropped to client, exiting...");
+                if !SERVER_PERSIST {
+                    std::process::exit(0);
+                } else {
+                    server_reset = true;
+                }
+            }
+            *message_size = read_len;
         }
-        setup_socket_and_listen().expect("failed to reset server");
-    } else {
-        CLIENT_CONNECTION.set(stream).unwrap();
+        None => {
+            unreachable!("Client connection lost")
+        }
     }
-
-    *message_size = read_len;
-
+    // Do the reset so we don't deadlock when attempting to lock on
+    // CLIENT_CONNECTION in the subsequent call to `setup_socket_and_listen`
+    if server_reset {
+        setup_socket_and_listen().expect("failed to reset server");
+    }
     0
 }
 
@@ -165,14 +179,7 @@ fn setup_socket_and_listen() -> Result<(), ()> {
         match client {
             Ok(client_connection) => {
                 /* connection succeeded */
-                unsafe {
-                    // TODO: It would be nice to somehow save this in libspdm
-                    // context
-                    CLIENT_CONNECTION.set(client_connection).map_err(|e| {
-                        error!("Failed to set/save client connection: {e:?}");
-                        ()
-                    })?;
-                }
+                *(CLIENT_CONNECTION.lock().unwrap()) = Some(client_connection);
                 info!("Client connected");
                 break;
             }
@@ -182,6 +189,7 @@ fn setup_socket_and_listen() -> Result<(), ()> {
             }
         }
     }
+
     Ok(())
 }
 

--- a/src/usb_i2c.rs
+++ b/src/usb_i2c.rs
@@ -27,7 +27,7 @@ use lazy_static::lazy_static;
 use libmctp;
 use libmctp::mctp_traits::SMBusMCTPRequestResponse;
 use libmctp::vendor_packets::VendorIDFormat;
-use once_cell::sync::OnceCell;
+use once_cell::sync::Lazy;
 use serialport::SerialPort;
 use std::io::Read;
 use std::slice::{from_raw_parts, from_raw_parts_mut};
@@ -65,7 +65,7 @@ const VENDOR_IDS: [VendorIDFormat; 1] = [VendorIDFormat {
     numeric_value: 0xAB,
 }];
 
-static mut MCTPCONTEXT: OnceCell<libmctp::MCTPSMBusContext> = OnceCell::new();
+static MCTPCONTEXT: Lazy<Mutex<Option<libmctp::MCTPSMBusContext>>> = Lazy::new(|| Mutex::new(None));
 
 lazy_static! {
     // Let's lock down the serial port, so we don't have to keep opening and
@@ -99,58 +99,62 @@ unsafe extern "C" fn usb_i2c_send_message(
     message_ptr: *const c_void,
     _timeout: u64,
 ) -> u32 {
-    assert!(message_size < SEND_RECEIVE_BUFFER_LEN as usize);
-    let message = message_ptr as *const u8;
-    let msg_buf = unsafe { from_raw_parts(message, message_size) };
-    let mut send_buf: [u8; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize] =
-        [0; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize];
-    let ctx = MCTPCONTEXT.take().unwrap();
+    match &mut *MCTPCONTEXT.lock().unwrap() {
+        Some(mctp_ctx) => {
+            assert!(message_size < SEND_RECEIVE_BUFFER_LEN as usize);
+            let message = message_ptr as *const u8;
+            let msg_buf = unsafe { from_raw_parts(message, message_size) };
+            let mut send_buf: [u8; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize] =
+                [0; (SEND_RECEIVE_BUFFER_LEN + HEADER_LEN) as usize];
 
-    let libspdm_msg_header_type = match libmctp::MessageType::from(msg_buf[0]) {
-        libmctp::MessageType::SpdmOverMctp => libmctp::MessageType::SpdmOverMctp,
-        libmctp::MessageType::SecuredMessages => libmctp::MessageType::SecuredMessages,
-        _ => unreachable!("unexpected mctp/spdm message type"),
-    };
+            let libspdm_msg_header_type = match libmctp::MessageType::from(msg_buf[0]) {
+                libmctp::MessageType::SpdmOverMctp => libmctp::MessageType::SpdmOverMctp,
+                libmctp::MessageType::SecuredMessages => libmctp::MessageType::SecuredMessages,
+                _ => unreachable!("unexpected mctp/spdm message type"),
+            };
 
-    let mut len = ctx
-        .get_request()
-        .generate_spdm_msg_packet_bytes(
-            TARGET_ID,
-            libspdm_msg_header_type,
-            &None,
-            &msg_buf[1..],
-            &mut send_buf,
-        )
-        .unwrap();
+            let mut len = mctp_ctx
+                .get_request()
+                .generate_spdm_msg_packet_bytes(
+                    TARGET_ID,
+                    libspdm_msg_header_type,
+                    &None,
+                    &msg_buf[1..],
+                    &mut send_buf,
+                )
+                .unwrap();
 
-    debug!("Full MCTP message {:x?}", &send_buf[..len]);
+            debug!("Full MCTP message {:x?}", &send_buf[..len]);
 
-    // We drop the first byte, which is the target address
-    send_buf.copy_within(0..len, HEADER_LEN - 1);
-    len = len - 1;
+            // We drop the first byte, which is the target address
+            send_buf.copy_within(0..len, HEADER_LEN - 1);
+            len = len - 1;
 
-    send_buf[0] = 0xAA; // Preamble
-    send_buf[1] = TARGET_ID; // Target Address
-    send_buf[2..=3].copy_from_slice(&u16::to_be_bytes(len as u16)); // Set the 16-bit length value [2] -> upper byte, [3] -> lower byte
+            send_buf[0] = 0xAA; // Preamble
+            send_buf[1] = TARGET_ID; // Target Address
+            send_buf[2..=3].copy_from_slice(&u16::to_be_bytes(len as u16)); // Set the 16-bit length value [2] -> upper byte, [3] -> lower byte
 
-    // For writes, we transfer the entire buffer of fixed length.
-    debug!(
-        "MCTP message Length {:} || SPDM Len: {:} || Total TX Length {:?}",
-        len,
-        message_size,
-        send_buf.len()
-    );
+            // For writes, we transfer the entire buffer of fixed length.
+            debug!(
+                "MCTP message Length {:} || SPDM Len: {:} || Total TX Length {:?}",
+                len,
+                message_size,
+                send_buf.len()
+            );
 
-    debug!("Sending message {:x?}", &send_buf[..(len + HEADER_LEN)]);
+            debug!("Sending message {:x?}", &send_buf[..(len + HEADER_LEN)]);
 
-    // Write out the data buffer
-    let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
-    port.write(&send_buf).expect("Write failed!");
-    info!("Sent!");
+            // Write out the data buffer
+            let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
+            port.write(&send_buf).expect("Write failed!");
+            info!("Sent!");
 
-    let _ = MCTPCONTEXT.set(ctx);
-    *SERIAL_PORT.lock().unwrap() = Some(port);
-
+            *SERIAL_PORT.lock().unwrap() = Some(port);
+        }
+        None => {
+            unreachable!("MCTP Context lost")
+        }
+    }
     0
 }
 
@@ -181,60 +185,64 @@ unsafe extern "C" fn usb_i2c_receive_message(
     message_ptr: *mut *mut c_void,
     _timeout: u64,
 ) -> u32 {
-    let message = *message_ptr as *mut u8;
-    let spdm_msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
-    spdm_msg_buf.fill(0);
-    let ctx = MCTPCONTEXT.take().unwrap();
+    match &mut *MCTPCONTEXT.lock().unwrap() {
+        Some(mctp_ctx) => {
+            let message = *message_ptr as *mut u8;
+            let spdm_msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+            spdm_msg_buf.fill(0);
 
-    info!("Receiving message");
+            info!("Receiving message");
 
-    let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
-    let mut header: Vec<u8> = vec![0; HEADER_LEN];
-    _ = port.read_exact(&mut header).unwrap();
+            let mut port = SERIAL_PORT.lock().unwrap().take().unwrap();
+            let mut header: Vec<u8> = vec![0; HEADER_LEN];
+            _ = port.read_exact(&mut header).unwrap();
 
-    // Assert the header first
-    debug!("packet_header: {:x?}", header);
-    assert_eq!(header[0], 0xBB); // Receive Preamble 1
-    assert_eq!(header[1], 0xFF); // Receive Preamble 2 (This is just misc)
+            // Assert the header first
+            debug!("packet_header: {:x?}", header);
+            assert_eq!(header[0], 0xBB); // Receive Preamble 1
+            assert_eq!(header[1], 0xFF); // Receive Preamble 2 (This is just misc)
 
-    // Copy in the 2 bytes (Big Endian as set by target) that corresponds to the
-    // message length
-    let mut message_len = u16::from_be_bytes([header[2], header[3]]) as usize;
-    assert!(message_len <= SEND_RECEIVE_BUFFER_LEN);
-    assert_ne!(message_len, 0x00);
+            // Copy in the 2 bytes (Big Endian as set by target) that corresponds to the
+            // message length
+            let mut message_len = u16::from_be_bytes([header[2], header[3]]) as usize;
+            assert!(message_len <= SEND_RECEIVE_BUFFER_LEN);
+            assert_ne!(message_len, 0x00);
 
-    // Read the next set of data, which is just the SPDM message
-    port.read_exact(&mut spdm_msg_buf[0..message_len]).unwrap();
+            // Read the next set of data, which is just the SPDM message
+            port.read_exact(&mut spdm_msg_buf[0..message_len]).unwrap();
 
-    debug!("Received: {:x?}", &spdm_msg_buf[0..message_len]);
+            debug!("Received: {:x?}", &spdm_msg_buf[0..message_len]);
 
-    // Amend our address to create a valid MCTP packet
-    spdm_msg_buf.copy_within(0..message_len, 1);
-    spdm_msg_buf[0] = SOURCE_ID << 1;
-    message_len = message_len + 1;
+            // Amend our address to create a valid MCTP packet
+            spdm_msg_buf.copy_within(0..message_len, 1);
+            spdm_msg_buf[0] = SOURCE_ID << 1;
+            message_len = message_len + 1;
 
-    // Get the total length from the MCTP packet
-    let mctp_len = spdm_msg_buf[MCTP_BYTE_COUNT] as usize + 4;
-    assert!(mctp_len <= message_len);
-    assert!(mctp_len <= SEND_RECEIVE_BUFFER_LEN);
+            // Get the total length from the MCTP packet
+            let mctp_len = spdm_msg_buf[MCTP_BYTE_COUNT] as usize + 4;
+            assert!(mctp_len <= message_len);
+            assert!(mctp_len <= SEND_RECEIVE_BUFFER_LEN);
 
-    let (_msg_type, payload) = ctx.decode_packet(&spdm_msg_buf[0..mctp_len]).unwrap();
+            let (_msg_type, payload) = mctp_ctx.decode_packet(&spdm_msg_buf[0..mctp_len]).unwrap();
 
-    // Extract the payload and add the mesasge type to please libspdm
-    let len = payload.len() + 1;
-    // The `MCTP_PAYLOAD_OFFSET-1`` is the SPDM MCTP Message type, lets retain this
-    spdm_msg_buf.copy_within(
-        (MCTP_PAYLOAD_OFFSET - 1)..((MCTP_PAYLOAD_OFFSET - 1) + len),
-        0,
-    );
+            // Extract the payload and add the mesasge type to please libspdm
+            let len = payload.len() + 1;
+            // The `MCTP_PAYLOAD_OFFSET-1`` is the SPDM MCTP Message type, lets retain this
+            spdm_msg_buf.copy_within(
+                (MCTP_PAYLOAD_OFFSET - 1)..((MCTP_PAYLOAD_OFFSET - 1) + len),
+                0,
+            );
 
-    debug!("mctp_buf: {:x?}", &spdm_msg_buf[0..len]);
+            debug!("mctp_buf: {:x?}", &spdm_msg_buf[0..len]);
 
-    *message_size = len;
+            *message_size = len;
 
-    let _ = MCTPCONTEXT.set(ctx);
-    *SERIAL_PORT.lock().unwrap() = Some(port);
-
+            *SERIAL_PORT.lock().unwrap() = Some(port);
+        }
+        None => {
+            unreachable!("MCTP Context lost")
+        }
+    }
     0
 }
 
@@ -300,11 +308,12 @@ pub fn register_device(
         .replace(port);
 
     unsafe {
-        let _ = MCTPCONTEXT.set(libmctp::MCTPSMBusContext::new(
+        let mctp_ctx = Some(libmctp::MCTPSMBusContext::new(
             SOURCE_ID,
             &MSG_TYPES,
             &VENDOR_IDS,
         ));
+        *(MCTPCONTEXT.lock().unwrap()) = mctp_ctx;
 
         libspdm_register_device_io_func(
             context,


### PR DESCRIPTION
With rust2024 [1],  "The [static_mut_refs](https://doc.rust-lang.org/nightly/rustc/lints/listing/warn-by-default.html#static-mut-refs) lint level is now deny by default. This checks for taking a shared or mutable reference to a static mut."

This patch set aims to fix all these warning by replacing `static muts` with types that provide interior mutability and thread safety.

[1] https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html