### PR TITLE
[RFC] transport: spdm-storage: add support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,7 +139,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "synstructure 0.13.1",
 ]
 
@@ -162,7 +162,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -318,7 +318,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -363,9 +363,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "byteorder"
@@ -407,9 +407,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.27"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -429,14 +429,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -589,14 +589,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
 
 [[package]]
 name = "either"
@@ -735,7 +735,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1048,7 +1048,7 @@ checksum = "bd2209fff77f705b00c737016a48e73733d7fbccb8b007194db148f03561fb70"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1256,7 +1256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1317,9 +1317,9 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rusticata-macros"
@@ -1372,7 +1372,7 @@ checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1484,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1513,7 +1513,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1542,7 +1542,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1619,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
+checksum = "a210d160f08b701c8721ba1c726c11662f877ea6b7094007e1ca9a1041945034"
 
 [[package]]
 name = "unicode-segmentation"
@@ -1687,7 +1687,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -1722,7 +1722,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -22,6 +22,7 @@ dependencies = [
  "minicbor-derive",
  "nix 0.29.0",
  "once_cell",
+ "page_size",
  "serialport",
  "sha2",
  "which",
@@ -1158,6 +1159,16 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "page_size"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "parking"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,9 @@ std = [
     "futures",
     "nix",
     "inquire",
+    "page_size",
 ]
+page_size = ["dep:page_size"]
 
 [lib]
 name = "libspdm"
@@ -61,6 +63,7 @@ colored = { version = "2.1", optional = true }
 which = { version = "6.0", optional = true }
 asn1-rs = { version = "0.6", optional = true }
 x509-parser = { version = "0.15", optional = true }
+page_size = { version = "0.6.0", optional = true }
 minicbor = { version = "0.25", features = [
     "half",
     "alloc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ std = [
     "inquire",
     "page_size",
 ]
-page_size = ["dep:page_size"]
 
 [lib]
 name = "libspdm"
@@ -75,7 +74,7 @@ minicbor-derive = { version = "0.15", features = [
 ], optional = true }
 async-std = { version = "1.12", features = ["attributes"], optional = true }
 futures = { version = "0.3", optional = true }
-nix = { version = "0.29.0", features = ["user", "fs"], optional = true }
+nix = {version = "0.29.0", features = ["user", "fs", "ioctl"], optional = true }
 libmctp = { version = "0.2" }
 inquire = { version = "0.7.5", optional = true}
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,7 +75,7 @@ minicbor-derive = { version = "0.15", features = [
 ], optional = true }
 async-std = { version = "1.12", features = ["attributes"], optional = true }
 futures = { version = "0.3", optional = true }
-nix = { version = "0.29.0", features = ["user"], optional = true }
+nix = { version = "0.29.0", features = ["user", "fs"], optional = true }
 libmctp = { version = "0.2" }
 inquire = { version = "0.7.5", optional = true}
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ See LICENSE-APACHE, LICENSE-MIT, and COPYRIGHT for details.
     - [Setting the certificate](#setting-the-certificate)
     - [Getting a Certificate Signing Request](#getting-a-certificate-signing-request)
     - [Signing a Certificate Signing Request](#signing-a-certificate-signing-request)
-- [QEMU SPDM Device Emulation](#qemu-spdm-device-emulation)
+- [Responder emulation with QEMU](#responder-emulation-with-qemu)
+    - [Using a QEMU emulated NVMe device with SPDM over DoE](#using-a-qemu-emulated-nvme-device-with-spdm-over-doe)
+    - [Using a QEMU emulated NVMe device with SPDM over Storage](#using-a-qemu-emulated-nvme-device-with-spdm-over-storage)
+- [tcmu-runner SPDM Device Emulation](#tcmu-runner-spdm-device-emulation)
 
 # Dependencies
 
@@ -56,11 +59,11 @@ Note: `dnf` commands are for Fedora, and `apt` is used for Debian/Ubuntu based
 distributions.
 
 ```shell
-$ sudo dnf install cmake clang-libs clang-devel pciutils-devel openssl openssl-devel python3-devel systemd-devel
+$ sudo dnf install cmake clang-libs clang-devel pciutils-devel openssl openssl-devel python3-devel systemd-devel libnvme
 
 or
 
-$ sudo apt install cmake clang libclang-dev pciutils libpci-dev openssl libssl-dev libsystemd-dev python3-dev pkg-config
+$ sudo apt install cmake clang libclang-dev pciutils libpci-dev openssl libssl-dev libsystemd-dev python3-dev pkg-config libnvme-dev
 ```
 
 ### Ruby
@@ -298,6 +301,15 @@ invoked as below:
 ./target/debug/spdm_utils --pcie-vid <VendorID> --pcie-devid <DeviceID> --doe-pci-cfg request get-digests
 ```
 
+### Interacting with SCSI/NVMe devices over SPDM over Storage Transport
+
+SPDM-utils supports the SPDM over storage transport as defined by the DMTF DSP0286.
+For example, the following command can be used to interact with an NVMe device.
+
+```shell
+$ ./target/debug/spdm_utils --blk-dev-path /dev/nvme0 --nvme --no-session request get-version,get-capabilities
+```
+
 ## Setting the certificate
 
 From a host you can set the certificate of the device. As SPDM-Utils uses
@@ -377,8 +389,7 @@ cd certs
 ./setup_certs.sh ../target/debug/spdm_utils
 cd ../
 ```
-
-# QEMU SPDM Device Emulation
+# Responder emulation with QEMU
 
 SPDM-Utils supports binding to QEMU to implement an SPDM responder side to
 an emulated device in QEMU. SPDM support for QEMU is not upstream yet, however,
@@ -389,8 +400,11 @@ over DOE.
 For example, this may be an emulated NVMe device
 in QEMU that binds to SPDM-Utils for the SPDM responder implementation.
 
-With the current SPDM implementation in QEMU, the only transport layer supported
-is DOE. SPDM-Utils must be started before QEMU for this to work.
+## Using a QEMU emulated NVMe device with SPDM over DoE
+
+For this example, we are using DOE. This is the transport protocol that
+SPDM-Utils defaults to when not explicitly specified. SPDM-Utils must be started
+before QEMU for this to work.
 
 ```shell
 $ ./target/debug/spdm_utils --qemu-server response
@@ -413,3 +427,78 @@ should show (ensure that INFO log level is enabled in SPDM-Utils).
 ```
 
 Now QEMU is ready to use SPDM-Utils as an SPDM responder for an emulated device.
+
+## Using a QEMU emulated NVMe device with SPDM over Storage
+
+In this example, let's look at using the an emulated NVMe device on QEMU that
+uses the SPDM over Storage transport protocol. That is, SPDM messages are
+communicated to the NVMe device through the NVMe Security Send/Receive commands.
+
+As before, we need to start SPDM-Utils before QEMU, the following options are
+required.
+
+```shell
+$ ./target/debug/spdm_utils --qemu-server --spdm-transport-protocol=storage response
+
+[2024-06-07T00:09:06Z DEBUG spdm_utils] Logger initialisation [OK]
+[2024-06-07T00:09:06Z INFO  spdm_utils] Using Nvme transport for QEMU
+[2024-06-07T00:09:06Z DEBUG spdm_utils::qemu_server] Setting up a server on [port: 2323, ip: 127.0.0.1]
+[2024-06-07T00:09:06Z INFO  spdm_utils::qemu_server] Server started, waiting for qemu on port: 2323
+```
+
+You can now start the QEMU guest and the connection to the SPDM-Utils responder
+server shall be established.
+
+# tcmu-runner SPDM Device Emulation
+
+tcmu-runner is a daemon that handles the user-space side of the LIO TCM-User
+backstore. Using `tcmu-runner` and the `target_core_user` kernel module we
+can emulate a ZBC block device that supports SPDM. We use SPDM-Utils to
+encode/decode the messages as a responder. Any tool can then be used to
+interact with the block device as a requester. In this example we use
+SPDM-Utils for this as well.
+
+### Start SPDM-Utils response server
+
+First we want to start a SPDM-Utils server to act as a SPDM responder.
+
+```shell
+$ ./target/debug/spdm_utils --spdm-transport-protocol=storage --qemu-server response
+```
+
+### Start tcmu-runner
+
+Then start `tcmu-runner`, it will connect to SPDM-Utils
+
+```shell
+$ sudo tcmu-runner --debug
+```
+
+### Create a block device
+
+We can now setup the block device
+
+```shell
+$ sudo ./scripts/scsi/create-disk-spdm.sh tcmudevel 2 HM 128 10
+```
+
+If you now run `lsscsi` you should see a `TCMU` entry
+
+```
+[2:0:1:0]    zbc     LIO-ORG  TCMU ZBC device  0002  /dev/sda
+```
+
+### Run a requester (SPDM-Utils)
+
+```shell
+$ sudo ./target/debug/spdm_utils --scsi --blk-dev-path=/dev/sda request get-version
+```
+
+### Teardown/remove the created block device.
+
+To remove the block device, the following script can be used while `tcmu-runner`
+is still active
+
+```shell
+$ sudo ./teardown-disk.sh tcmudevel
+```

--- a/build.rs
+++ b/build.rs
@@ -22,6 +22,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-Wl,--start-group");
 
     println!("cargo:rustc-link-arg=-lpci");
+    println!("cargo:rustc-link-arg=-lnvme");
 
     println!("cargo:rustc-link-arg=-lmemlib");
     println!("cargo:rustc-link-arg=-lmalloclib");

--- a/build.rs
+++ b/build.rs
@@ -41,6 +41,7 @@ fn main() {
     println!("cargo:rustc-link-arg=-lspdm_crypt_ext_lib");
     println!("cargo:rustc-link-arg=-lspdm_transport_pcidoe_lib");
     println!("cargo:rustc-link-arg=-lspdm_transport_mctp_lib");
+    println!("cargo:rustc-link-arg=-lspdm_transport_storage_lib");
 
     // Link SPDM Test Libraries
     let mut builder = if cfg!(feature = "libspdm_tests") {

--- a/scripts/scsi/create-disk-spdm.sh
+++ b/scripts/scsi/create-disk-spdm.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+if [ $# != 5 ]; then
+        echo "Usage: $0 <disk name> <cap (GB)> HM|HA <zone size (MB)> <conv zones num>"
+        exit 1;
+fi
+
+dname="$1"
+cap="$2"
+model="$3"
+zs="$4"
+cnum="$5"
+
+naa="naa.50014059cfa9ba75"
+
+# Setup emulated disk
+cat << EOF | targetcli
+
+cd /backstores/user:zbc
+create name=${dname} size=${cap}G cfgstring=model-${model}/zsize-${zs}/conv-${cnum}/spdm-2323@/var/local/${dname}.raw
+cd /loopback
+create ${naa}
+cd ${naa}/luns
+create /backstores/user:zbc/${dname} 0
+cd /
+exit
+
+EOF
+
+sleep 1
+disk=`lsscsi | grep "TCMU ZBC device" | cut -d '/' -f3 | sed 's/ //g'`
+echo "mq-deadline" > /sys/block/"${disk}"/queue/scheduler

--- a/scripts/scsi/teardown-disk.sh
+++ b/scripts/scsi/teardown-disk.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+if [ $# != 1 ]; then
+	echo "Usage: $0 <disk name (e.g. zbc0)"
+	exit 1;
+fi
+
+dname="$1"
+
+naa="naa.50014059cfa9ba75"
+
+# Delete emulated disk
+cat << EOF | targetcli
+
+cd /loopback/${naa}/luns
+delete 0
+cd /loopback
+delete ${naa}
+cd /backstores/user:zbc
+delete ${dname}
+cd /
+exit
+
+EOF

--- a/src/io_buffers.rs
+++ b/src/io_buffers.rs
@@ -1,9 +1,78 @@
+use nix::errno::Errno;
 use once_cell::sync::Lazy;
 use std::ffi::c_void;
 use std::sync::Mutex;
 
-static SEND_BUFFER: Lazy<Mutex<Option<Vec<u8>>>> = Lazy::new(|| Mutex::new(None));
-static RECEIVE_BUFFER: Lazy<Mutex<Option<Vec<u8>>>> = Lazy::new(|| Mutex::new(None));
+static SEND_BUFFER: Lazy<Mutex<Option<BufferType>>> = Lazy::new(|| Mutex::new(None));
+static RECEIVE_BUFFER: Lazy<Mutex<Option<BufferType>>> = Lazy::new(|| Mutex::new(None));
+
+enum BufferType {
+    MemAligned(Vec<u8>),
+    Default(Vec<u8>),
+}
+
+impl BufferType {
+    fn into(&self) -> &Vec<u8> {
+        match self {
+            BufferType::MemAligned(data) | BufferType::Default(data) => data,
+        }
+    }
+}
+
+pub unsafe fn libspdm_setup_pagealigned_io_buffers(
+    context: *mut c_void,
+    send_recv_len: usize,
+    libsdpm_buff_len: usize,
+) -> Result<(), Errno> {
+    let mut buffer_send: *mut c_void = std::ptr::null_mut();
+    let mut buffer_recv: *mut c_void = std::ptr::null_mut();
+
+    if send_recv_len % page_size::get() != 0 {
+        error!("Requested SEND/RECV buffer size is not target page size aligned");
+        return Err(Errno::EINVAL);
+    }
+
+    // The buffers are page aligned, useful for NVMe userspace API buffers.
+    if nix::libc::posix_memalign(
+        &mut buffer_recv as *mut *mut c_void,
+        page_size::get(),
+        send_recv_len,
+    ) != 0
+    {
+        error!("Failed to allocate an aligned receive buffer");
+        return Err(Errno::ENOMEM);
+    }
+    if nix::libc::posix_memalign(
+        &mut buffer_send as *mut *mut c_void,
+        page_size::get(),
+        send_recv_len,
+    ) != 0
+    {
+        error!("Failed to allocate an aligned send buffer");
+        return Err(Errno::ENOMEM);
+    }
+
+    nix::libc::memset(buffer_send, 0, send_recv_len);
+    nix::libc::memset(buffer_recv, 0, send_recv_len);
+
+    let buffer_send = Vec::from_raw_parts(buffer_send as *mut u8, send_recv_len, send_recv_len);
+    let buffer_recv = Vec::from_raw_parts(buffer_recv as *mut u8, send_recv_len, send_recv_len);
+
+    *(SEND_BUFFER.lock().unwrap()) = Some(BufferType::MemAligned(buffer_send));
+    *(RECEIVE_BUFFER.lock().unwrap()) = Some(BufferType::MemAligned(buffer_recv));
+
+    libspdm::libspdm_rs::libspdm_register_device_buffer_func(
+        context,
+        libsdpm_buff_len as u32,
+        libsdpm_buff_len as u32,
+        Some(acquire_sender_buffer),
+        Some(release_sender_buffer),
+        Some(acquire_receiver_buffer),
+        Some(release_receiver_buffer),
+    );
+
+    Ok(())
+}
 
 pub fn libspdm_setup_io_buffers(
     context: *mut c_void,
@@ -18,8 +87,8 @@ pub fn libspdm_setup_io_buffers(
 
     match result {
         Ok(buffers) => {
-            *(SEND_BUFFER.lock().unwrap()) = Some(buffers.0);
-            *(RECEIVE_BUFFER.lock().unwrap()) = Some(buffers.1);
+            *(SEND_BUFFER.lock().unwrap()) = Some(BufferType::Default(buffers.0));
+            *(RECEIVE_BUFFER.lock().unwrap()) = Some(BufferType::Default(buffers.1));
 
             unsafe {
                 libspdm::libspdm_rs::libspdm_register_device_buffer_func(
@@ -60,11 +129,10 @@ pub unsafe extern "C" fn acquire_sender_buffer(
     msg_buf_ptr: *mut *mut c_void,
 ) -> u32 {
     if let Some(ref buf) = *SEND_BUFFER.lock().unwrap() {
-        let buf_ptr = buf.as_ptr() as *mut c_void;
+        let buf_ptr = buf.into().as_ptr() as *mut c_void;
         *msg_buf_ptr = buf_ptr;
         return 0;
     }
-
     error!("Sender buffer is lost or not initialized");
     1
 }
@@ -88,7 +156,7 @@ pub unsafe extern "C" fn acquire_receiver_buffer(
     msg_buf_ptr: *mut *mut c_void,
 ) -> u32 {
     if let Some(ref buf) = *RECEIVE_BUFFER.lock().unwrap() {
-        let buf_ptr = buf.as_ptr() as *mut c_void;
+        let buf_ptr = buf.into().as_ptr() as *mut c_void;
         *msg_buf_ptr = buf_ptr;
         return 0;
     }
@@ -115,16 +183,28 @@ pub unsafe extern "C" fn release_sender_buffer(_context: *mut c_void, _msg_buf_p
 /// memory.
 pub unsafe fn libspdm_drop_io_buffers() {
     let mut send_buf = SEND_BUFFER.lock().unwrap();
-    if send_buf.is_some() {
-        *send_buf = None;
+    if let Some(buffer) = send_buf.take() {
+        let mut data = match buffer {
+            BufferType::MemAligned(vec) | BufferType::Default(vec) => vec,
+        };
+        let ptr = data.as_mut_ptr() as *mut c_void;
+        // Forget to avoid, double free when this goes out of scope.
+        std::mem::forget(data);
+        nix::libc::free(ptr);
     } else {
-        warn!("Send buffer is lost or not initialized");
+        error!("Send buffer is lost or not initialized");
     }
 
     let mut recv_buf = RECEIVE_BUFFER.lock().unwrap();
-    if recv_buf.is_some() {
-        *recv_buf = None;
+    if let Some(buffer) = recv_buf.take() {
+        let mut data = match buffer {
+            BufferType::MemAligned(vec) | BufferType::Default(vec) => vec,
+        };
+        let ptr = data.as_mut_ptr() as *mut c_void;
+        // Forget to avoid, double free when this goes out of scope.
+        std::mem::forget(data);
+        nix::libc::free(ptr);
     } else {
-        warn!("Receive buffer is lost or not initialized");
+        error!("Receive buffer is lost or not initialized");
     }
 }

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -277,6 +277,8 @@ pub enum TransportLayer {
     Doe,
     /// DMTF Management Component Transport Protocol
     Mctp,
+    /// SCSI Security Protocol In/Out commands
+    Storage,
 }
 
 #[cfg(feature = "no_std")]
@@ -499,6 +501,16 @@ pub unsafe fn setup_transport_layer(
                 LIBSPDM_MCTP_TRANSPORT_TAIL_SIZE,
                 Some(libspdm_transport_mctp_encode_message),
                 Some(libspdm_transport_mctp_decode_message),
+            );
+        }
+        TransportLayer::Storage => {
+            libspdm_register_transport_layer_func(
+                context,
+                libspdm_max_spdm_msg_size,
+                LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE,
+                LIBSPDM_STORAGE_TRANSPORT_TAIL_SIZE,
+                Some(libspdm_transport_storage_encode_message),
+                Some(libspdm_transport_storage_decode_message),
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use async_std::task;
 use clap::{Parser, Subcommand};
 use futures::future::join_all;
 use libspdm::libspdm_rs::*;
+use nix::errno::Errno;
 use nix::unistd::geteuid;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fs::File;
@@ -31,6 +32,7 @@ mod doe_pci_cfg;
 mod io_buffers;
 mod qemu_server;
 mod request;
+mod scsi;
 mod socket_client;
 mod socket_server;
 mod tcg_concise_evidence_binding;
@@ -42,6 +44,14 @@ mod usb_i2c;
 struct Args {
     #[command(subcommand)]
     command: Commands,
+
+    /// Use SCSI commands for the target device
+    #[arg(short, long, requires_ifs([("true", "blk_dev_path")]))]
+    scsi: bool,
+
+    /// Path to the SCSI block device
+    #[arg(long)]
+    blk_dev_path: Option<String>,
 
     /// Use the Linux PCIe extended configuration backend
     /// This is generally run on the Linux host machine
@@ -641,6 +651,9 @@ async fn main() -> Result<(), ()> {
 
     let mut count = 0;
 
+    cli.scsi.then(|| {
+        count += 1;
+    });
     cli.doe_pci_cfg.then(|| {
         count += 1;
     });
@@ -703,8 +716,16 @@ async fn main() -> Result<(), ()> {
                 return Err(());
             }
         }
-
         usb_i2c::register_device(cntx_ptr, cli.usb_i2c_dev, cli.usb_i2c_baud)?;
+    } else if cli.scsi {
+        scsi::cmd_scsi_get_info(&cli.blk_dev_path.clone().unwrap()).unwrap();
+        if let Err(e) = scsi::cmd_scsi_get_sec_info(&cli.blk_dev_path.clone().unwrap()) {
+            if e == Errno::ENOTSUP {
+                error!("SPDM is not supported by this device");
+                return Err(());
+            }
+        }
+        scsi::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap())?;
     } else if cli.qemu_server {
         if let Commands::Request { .. } = cli.command {
             error!("QEMU Server does not support running an SPDM requester");
@@ -729,6 +750,13 @@ async fn main() -> Result<(), ()> {
                 spdm::TransportLayer::Mctp,
                 spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
             )?;
+        } else if cli.scsi {
+            spdm::setup_transport_layer(
+                cntx_ptr,
+                spdm::TransportLayer::Storage,
+                spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
+            )
+            .unwrap();
         } else {
             spdm::setup_transport_layer(
                 cntx_ptr,

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,11 +30,13 @@ pub static SOCKET_PATH: &str = "SPDM-Utils-loopback-socket";
 mod cli_helpers;
 mod doe_pci_cfg;
 mod io_buffers;
+mod nvme;
 mod qemu_server;
 mod request;
 mod scsi;
 mod socket_client;
 mod socket_server;
+mod storage_standards;
 mod tcg_concise_evidence_binding;
 mod test_suite;
 mod usb_i2c;
@@ -49,7 +51,15 @@ struct Args {
     #[arg(short, long, requires_ifs([("true", "blk_dev_path")]))]
     scsi: bool,
 
-    /// Path to the SCSI block device
+    /// Use NVMe commands for the target device
+    #[arg(short, long, requires_ifs([("true", "blk_dev_path")]))]
+    nvme: bool,
+
+    /// NVME NameSpace Identifier
+    #[arg(long, default_value_t = 1)]
+    nsid: u32,
+
+    /// Path to the block device
     #[arg(long)]
     blk_dev_path: Option<String>,
 
@@ -654,6 +664,9 @@ async fn main() -> Result<(), ()> {
     cli.scsi.then(|| {
         count += 1;
     });
+    cli.nvme.then(|| {
+        count += 1;
+    });
     cli.doe_pci_cfg.then(|| {
         count += 1;
     });
@@ -726,12 +739,21 @@ async fn main() -> Result<(), ()> {
             }
         }
         scsi::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap())?;
+    } else if cli.nvme {
+        if let Err(e) = nvme::nvme_get_sec_info(&cli.blk_dev_path.clone().unwrap(), cli.nsid) {
+            if e == Errno::ENOTSUP {
+                error!("SPDM is not supported by this NVMe device");
+                return Err(());
+            }
+        }
+        nvme::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap(), cli.nsid).unwrap();
     } else if cli.qemu_server {
         if let Commands::Request { .. } = cli.command {
             error!("QEMU Server does not support running an SPDM requester");
             return Err(());
         }
         if let Some(proto) = cli.spdm_transport_protocol {
+            info!("Using {:?} transport for QEMU", proto);
             qemu_server::register_device(cntx_ptr, cli.qemu_port, proto)?;
         } else {
             qemu_server::register_device(cntx_ptr, cli.qemu_port, spdm::TransportLayer::Doe)?;
@@ -743,6 +765,7 @@ async fn main() -> Result<(), ()> {
 
     unsafe {
         if let Some(proto) = cli.spdm_transport_protocol {
+            info!("Using {:?} transport", proto);
             spdm::setup_transport_layer(cntx_ptr, proto, spdm::LIBSPDM_MAX_SPDM_MSG_SIZE)?;
         } else if cli.usb_i2c {
             spdm::setup_transport_layer(
@@ -750,7 +773,7 @@ async fn main() -> Result<(), ()> {
                 spdm::TransportLayer::Mctp,
                 spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
             )?;
-        } else if cli.scsi {
+        } else if cli.scsi || cli.nvme {
             spdm::setup_transport_layer(
                 cntx_ptr,
                 spdm::TransportLayer::Storage,

--- a/src/nvme.rs
+++ b/src/nvme.rs
@@ -1,0 +1,668 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2024, Western Digital Corporation or its affiliates.
+
+//! This file provides support for SPDM interfacing to a NVMe device
+//!
+//! SAFETY: This file includes a lot of unsafe Rust.
+//! If libspdm behaves in a manor we don't expect this will be very bad,
+//! so we are trusting libspdm here.
+//!
+
+use crate::*;
+use core::ffi::c_void;
+use core::ptr;
+use libspdm::spdm::LIBSPDM_MAX_SPDM_MSG_SIZE;
+use nix::errno::Errno;
+use nix::fcntl::{open, OFlag};
+use nix::sys::stat::{fstat, FileStat, Mode, SFlag};
+use nix::unistd::close;
+use std::slice::from_raw_parts;
+use std::sync::Mutex;
+use storage_standards::{SpcSecurityProtocols, SpdmOperationCodes};
+
+/// Limit maximum transfers to 4k, if we allocate bigger IO buffers, we then need
+/// to rely on kernel support mmap(2) with MAP_HUGETLB. To allocate aligned
+/// and contiguous buffers.
+const NVME_STORAGE_MSG_MAX_SIZE: usize = 4096;
+const LIBSPDM_MAX_TRANSPORT_MSG_LEN: usize = NVME_STORAGE_MSG_MAX_SIZE;
+
+static NVME_DEV: Lazy<Mutex<Option<NvmeDev>>> = Lazy::new(|| Mutex::new(None));
+/// Transfer lengths must be DWORD Aligned.
+const LIBNVME_RECV_ARG_MIN_AL_LEN: usize = 32;
+
+/// # Summary
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn nvme_send_message(
+    _context: *mut c_void,
+    message_size: usize,
+    message_ptr: *const c_void,
+    timeout_us: u64,
+) -> u32 {
+    debug!("Sending NVMe Security Send: SPDM Message");
+    let message = message_ptr as *const u8;
+    let mut dptr = unsafe { from_raw_parts(message, message_size) }.to_vec();
+
+    match &mut *NVME_DEV.lock().unwrap() {
+        Some(dev) => {
+            // Setup a security receive command for security protocol discovery
+            let mut cmd =
+                match NvmeSecSendCmds::gen_libspdm_encoded_sec_send_args(&mut dptr, dev.nsid) {
+                    Ok(cmd) => cmd,
+                    Err(why) => {
+                        panic!("Failed to generate SPDM Message Command: {:?}", why)
+                    }
+                };
+
+            debug!("NVME Storage Message Cmd: {:?}", cmd);
+            debug!("SPDM Request: {:x?}", &dptr[..message_size]);
+
+            if let Err(why) = dev.nvme_sec_send(&mut cmd, timeout_us) {
+                panic!("Failed to security send: {:?}", why);
+            }
+        }
+        None => unreachable!("NVMe device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `LIBSPDM_MAX_TRANSPORT_MSG_LEN` to capture the received bytes.
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn nvme_receive_message(
+    context: *mut c_void,
+    message_size: *mut usize,
+    message_ptr: *mut *mut c_void,
+    timeout_us: u64,
+) -> u32 {
+    debug!("Sending NVMe Security Receive: SPDM Message");
+    match &mut *NVME_DEV.lock().unwrap() {
+        Some(dev) => {
+            let message = *message_ptr as *mut u8;
+            // Setup a security receive command for security protocol discovery
+            let mut cmd = match NvmeSecRecvCmds::gen_libspdm_encoded_sec_recv_args(
+                context,
+                dev.nsid,
+                message,
+                *message_size,
+            ) {
+                Ok(cmd) => cmd,
+                Err(why) => {
+                    panic!("Failed to generate SPDM Message Command: {:?}", why)
+                }
+            };
+
+            debug!("NVME Storage Message Cmd: {:?}", cmd);
+
+            if let Err(why) = dev.nvme_sec_recv(&mut cmd, timeout_us) {
+                panic!("Failed to security receive: {:?}", why);
+            }
+            // Allow libspdm to do top-bottom SPDM message parsing, we don't know the
+            // number of valid bytes in the reception buffer.
+            *message_size = LIBSPDM_MAX_TRANSPORT_MSG_LEN;
+        }
+        None => unreachable!("NVMe device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+/// Setup device IO buffers and register the transport/IO functions to the
+/// given libspdm @context.
+///
+/// # Parameter
+///
+/// * `context`: The SPDM context
+///
+/// # Returns
+///
+/// Ok(()) on success
+///
+/// # Panics
+///
+/// Panics if `SEND_BUFFER/RECEIVE_BUFFER` is occupied
+pub fn register_device(context: *mut c_void, dev_path: &String, nsid: u32) -> Result<(), Errno> {
+    if LIBSPDM_MAX_TRANSPORT_MSG_LEN % page_size::get() != 0 {
+        error!("Requested SEND/RECV buffer size is not target page size aligned");
+        return Err(Errno::EINVAL);
+    }
+
+    if LIBSPDM_MAX_TRANSPORT_MSG_LEN > LIBSPDM_MAX_SPDM_MSG_SIZE as usize {
+        error!("NVMe Transport buffers bigger than libspdm max supported");
+        return Err(Errno::EINVAL);
+    }
+
+    let dev = NvmeDev::new(dev_path, nsid, OFlag::O_EXCL | OFlag::O_RDWR)
+        .expect("Failed to establish a connection to the NVMe Controller");
+    *NVME_DEV.lock().unwrap() = Some(dev);
+    unsafe {
+        libspdm_register_device_io_func(
+            context,
+            Some(nvme_send_message),
+            Some(nvme_receive_message),
+        );
+        io_buffers::libspdm_setup_pagealigned_io_buffers(
+            context,
+            LIBSPDM_MAX_TRANSPORT_MSG_LEN,
+            LIBSPDM_MAX_TRANSPORT_MSG_LEN,
+        )?;
+    }
+
+    Ok(())
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct NvmeDev {
+    fd: i32,
+    nsid: u32,
+    flags: OFlag,
+    stat: Option<FileStat>,
+}
+
+impl NvmeDev {
+    pub fn new(path: &String, nsid: u32, flags: OFlag) -> Result<NvmeDev, Errno> {
+        let path = Path::new(path);
+
+        info!("Getting device info for: {:?}", path);
+
+        match open(path, flags, Mode::S_IRUSR) {
+            Ok(fd) => {
+                let mut dev = NvmeDev {
+                    fd: fd,
+                    nsid: nsid,
+                    flags: flags,
+                    stat: None,
+                };
+
+                match fstat(fd) {
+                    Ok(fs) => {
+                        let st_mode = fs.st_mode;
+                        if !((SFlag::S_IFMT.bits() & st_mode) == SFlag::S_IFCHR.bits())
+                            && !((SFlag::S_IFMT.bits() & st_mode) == SFlag::S_IFBLK.bits())
+                        {
+                            error!("{:?} is not a block or character device", path);
+                            close(fd)?;
+                            return Err(Errno::ENODEV);
+                        }
+                        dev.stat = Some(fs);
+                    }
+                    Err(e) => {
+                        error!("Failed to do file stat for {:?}: {:?}", path, e);
+                        close(fd)?;
+                        return Err(e);
+                    }
+                }
+
+                return Ok(dev);
+            }
+            Err(e) => {
+                error!("Failed to open file {:?}: {:?}", path, e);
+                return Err(e);
+            }
+        }
+    }
+
+    /// # Summary
+    ///
+    /// The Security Send command transfers the security protocol data to the
+    /// controller. The data structure transferred to the controller as a part
+    /// of this command contains security protocol specific commands to be
+    /// performed by the controller.
+    ///
+    /// # Parameter
+    ///
+    /// * `cmd`: An initialized @nvme_security_send_args structure containing
+    ///          all required security protocol data.
+    /// * `timeout`: timeout to wait for in micro-seconds
+    ///
+    /// # Returns
+    ///
+    /// Ok(()) on success
+    /// Err(error_code, nvme_cmd_completion_status):
+    ///                   -1 with errno set, or if the response was received,
+    ///                   nvme_cmd_completion_status set to indicate the failure.
+    pub fn nvme_sec_send(
+        &mut self,
+        cmd: &mut nvme_security_send_args,
+        timeout_us: u64,
+    ) -> Result<(), i32> {
+        cmd.fd = self.fd;
+        if timeout_us == 0 || u32::try_from(timeout_us / 1_000).is_err() {
+            cmd.timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
+        } else {
+            // In nvme_security_send_args, timeout is represented in milliseconds
+            // https://github.com/linux-nvme/libnvme/blob/5585f06a4f849a1b43b1a04f387d2f9b5829744f/src/nvme/api-types.h#L313
+            cmd.timeout = u32::try_from(timeout_us / 1_000).unwrap();
+        }
+        // Call into libnvme
+        let rc = unsafe { nvme_security_send(cmd as *mut nvme_security_send_args) };
+        if rc != 0 {
+            error!("Security send: rc: {:} errno: {:}", rc, Errno::last());
+            return Err(rc);
+        }
+        debug!("Security Send Success");
+        Ok(())
+    }
+
+    /// # Summary
+    ///
+    /// The Security Receive command is used to obtain a security response from
+    /// the controller. This maybe used without a prior security send for actions
+    /// such as storage security discovery (Mandatory support by specification).
+    /// However, to obtain an SPDM response, it must follow a security send that
+    /// issues an SPDM request to the controller.
+    ///
+    /// # Parameter
+    ///
+    /// * `cmd`: An initialized @nvme_security_receive_args structure
+    ///          containing all required security protocol data.
+    /// * `timeout_us`: Timeout in micro-seconds
+    ///
+    /// # Returns
+    ///
+    /// Ok(()) on success
+    /// Err(error_code, nvme_cmd_completion_status):
+    ///                   -1 with errno set, or if the response was received,
+    ///                   nvme_cmd_completion_status set to indicate the failure.
+    pub fn nvme_sec_recv(
+        &mut self,
+        cmd: &mut nvme_security_receive_args,
+        timeout_us: u64,
+    ) -> Result<(), i32> {
+        cmd.fd = self.fd;
+        if timeout_us == 0 || u32::try_from(timeout_us / 1_000).is_err() {
+            cmd.timeout = NVME_DEFAULT_IOCTL_TIMEOUT;
+        } else {
+            // In nvme_security_send_args, timeout is represented in milliseconds
+            // https://github.com/linux-nvme/libnvme/blob/5585f06a4f849a1b43b1a04f387d2f9b5829744f/src/nvme/api-types.h#L313
+            cmd.timeout = u32::try_from(timeout_us / 1_000).unwrap();
+        }
+        // Call into libnvme
+        let rc = unsafe { nvme_security_receive(cmd as *mut nvme_security_receive_args) };
+        if rc != 0 {
+            error!("Security receive: CQE: {:} errno: {:}", rc, Errno::last());
+            return Err(rc);
+        }
+        debug!("Security Receive Success");
+        Ok(())
+    }
+}
+
+impl Drop for NvmeDev {
+    /// # Summary
+    ///
+    /// Close the underlying file-descriptor when this instance goes out of scope
+    ///
+    /// # Panics
+    ///
+    /// If the device file-descriptor was not set.
+    fn drop(&mut self) {
+        // This fd is valid as `self` does not exist on any failures
+        // to `open()` the NVMe device.
+        close(self.fd).expect("failed to NVMe close device file-descriptor");
+        debug!("NVMe device file-descriptor successfully closed");
+    }
+}
+
+struct NvmeSecSendCmds;
+struct NvmeSecRecvCmds;
+
+impl NvmeSecSendCmds {
+    /// # Summary
+    ///
+    /// Generates an @nvme_security_send_args suitable for an `SPDM Storage
+    /// Message`. @dptr shall be the message buffer that contains the SPDM
+    /// request data (with transport encoding from libspdm).
+    ///
+    /// # Note
+    ///
+    ///  A mutable reference to @dptr is stored within the returned struct, thus,
+    ///  the underlying memory pointed to by @dptr must not be free(d) until
+    ///  after the data is transferred. Ex: after invoking `nvme_security_send()`.
+    ///
+    /// # Parameter
+    ///
+    /// * `dptr`: A vector containing the SPDM request message (crosses FFI,
+    ///           i.e must be heap allocated).
+    /// * `nsid`: NVMe namespace identifier.
+    ///
+    /// # Returns
+    ///
+    /// Returns an initialised @nvme_security_send_args suitable for use for an
+    /// `NVMe Security Receive` command for an SPDM request.
+    ///
+    /// Returns Err(ENOMSG), if @dptr is empty
+    pub fn gen_libspdm_encoded_sec_send_args(
+        dptr: &mut Vec<u8>,
+        nsid: u32,
+    ) -> Result<nvme_security_send_args, Errno> {
+        if dptr.len() == 0 || dptr.len() < LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize {
+            // Nothing to send
+            return Err(Errno::ENOMSG);
+        }
+
+        let trans_hdr = unsafe { *(dptr.as_mut_ptr() as *mut storage_spdm_transport_header) };
+        assert_eq!(
+            trans_hdr.security_protocol,
+            u8::from(SpcSecurityProtocols::DmtfSpdm)
+        );
+        assert_eq!(trans_hdr.inc_512, false);
+        let spsp0: u8;
+        let spsp1: u8;
+        spsp0 = (trans_hdr.security_protocol_specific & 0xFF) as u8;
+        spsp1 = (trans_hdr.security_protocol_specific >> 8) as u8;
+
+        // Strip the transport header, only send the SPDM message.
+        // The transport relevant SPDM data is passed through the storage API.
+        let transfer_len = u32::from_le(trans_hdr.length) as usize
+            - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize;
+        if transfer_len <= 0 {
+            return Err(Errno::ENOMSG);
+        }
+        // Setup a security send command for an SPDM message
+        let args = nvme_security_send_args {
+            args_size: core::ffi::c_int::try_from(std::mem::size_of::<nvme_security_send_args>())
+                .unwrap(),
+            fd: 0, // Set at transport level
+            nsid: nsid,
+            nssf: 0, //RSVD
+            spsp0: spsp0,
+            spsp1: spsp1,
+            secp: trans_hdr.security_protocol,
+            tl: u32::try_from(transfer_len).unwrap(),
+            data_len: u32::try_from(transfer_len).unwrap(),
+            data: unsafe {
+                dptr.as_mut_ptr()
+                    .add(LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize)
+                    as *mut c_void
+            },
+            timeout: 0, // Set at transport
+            result: ptr::null_mut(),
+        };
+
+        Ok(args)
+    }
+}
+
+impl NvmeSecRecvCmds {
+    /// # Summary
+    ///
+    /// Generates an @nvme_security_receive_args suitable for an `SPDM Storage
+    /// Message` by using `libspdm` for transport encoding. This is suitable for
+    /// use in the libspdm message receive handler.
+    ///
+    /// @dptr shall be the message buffer into to which an SPDM response shall
+    /// be copied to, from the NVMe controller. As an SPDM Response maybe of
+    /// arbitrary size, a vector of capacity `LIBSPDM_MAX_TRANSPORT_MSG_LEN` is
+    /// enforced, to accommodate the worst case scenario.
+    ///
+    /// # Note
+    ///
+    ///  A mutable reference to @dptr is stored within the returned struct, thus,
+    ///  the underlying memory pointed to by @dptr must not be free(d) until
+    ///  after the data is received. Ex: after invoking `nvme_security_receive()`.
+    ///
+    /// # Parameter
+    ///
+    /// * `dptr`: A vector containing the SPDM request message (crosses FFI,
+    ///           i.e must be heap allocated).
+    /// * `nsid`: NVMe namespace identifier.
+    /// * `message`: libspdm message buffer
+    /// * `message_size`: libspdm message buffer size
+    ///
+    /// # Returns
+    ///
+    /// Returns an initialised @nvme_security_receive_args suitable for use for an
+    /// `NVMe Security Receive` command for an SPDM request.
+    ///
+    /// Returns Err(ENOMEM) if @dptr does not mean size requirements.
+    pub fn gen_libspdm_encoded_sec_recv_args(
+        context: *mut c_void,
+        nsid: u32,
+        message: *mut u8,
+        message_size: usize,
+    ) -> Result<nvme_security_receive_args, Errno> {
+        // Setup a security receive command for an SPDM message
+        let mut args = nvme_security_receive_args {
+            args_size:
+                core::ffi::c_int::try_from(std::mem::size_of::<nvme_security_receive_args>())
+                    .unwrap(),
+            fd: 0, // Set at transport level
+            nsid: nsid,
+            nssf: 0, //RSVD
+            spsp0: 0,
+            spsp1: 0, // RSVD
+            secp: 0,
+            al: LIBSPDM_MAX_TRANSPORT_MSG_LEN as u32,
+            data_len: 0,
+            data: message as *mut c_void,
+            timeout: 0, // Set at transport
+            result: ptr::null_mut(),
+        };
+
+        let mut transport_message_len = message_size;
+        let mut transport_message = ptr::null_mut();
+
+        unsafe {
+            let context = context as *mut libspdm_context_t;
+            assert!(
+                libspdm_transport_storage_encode_message(
+                    context as *mut c_void,
+                    ptr::null(),
+                    false,
+                    true,
+                    message_size - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize,
+                    message as *mut _ as *mut c_void,
+                    &mut transport_message_len,
+                    &mut transport_message as *mut *mut c_void,
+                ) == 0
+            );
+        }
+
+        assert!(transport_message_len >= LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize);
+        let trans_hdr =
+            unsafe { *(transport_message as *const u8 as *mut storage_spdm_transport_header) };
+        assert_eq!(
+            trans_hdr.security_protocol,
+            u8::from(SpcSecurityProtocols::DmtfSpdm)
+        );
+        assert_eq!(trans_hdr.inc_512, false);
+        // Update based on libspdm encoded data
+        args.secp = trans_hdr.security_protocol;
+        let spsp = u16::from_le(trans_hdr.security_protocol_specific);
+        args.spsp0 = (spsp & 0xFF) as u8;
+        args.spsp1 = (spsp >> 8) as u8;
+
+        assert!(args.spsp0 != 0);
+        assert!(args.spsp1 == 0);
+        assert!(LIBSPDM_MAX_TRANSPORT_MSG_LEN % page_size::get() == 0);
+        args.data_len = LIBSPDM_MAX_TRANSPORT_MSG_LEN as u32;
+
+        Ok(args)
+    }
+
+    pub fn gen_libspdm_encoded_discovery_request_args(
+        dptr: &mut Vec<u8>,
+        nsid: u32,
+    ) -> Result<nvme_security_receive_args, Errno> {
+        if dptr.len() < LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize {
+            return Err(Errno::ENOMEM);
+        }
+
+        if dptr.len() < LIBNVME_RECV_ARG_MIN_AL_LEN {
+            // Quirk: The dptr allocation length must be atleast 32 bytes,
+            // seeems to be an api limitation (?). The cmd will timeout otherwise.
+            return Err(Errno::ENOMEM);
+        }
+
+        let conn_id: u8 = 0;
+        // Setup a security send command for an SPDM message
+        let mut args = nvme_security_receive_args {
+            args_size:
+                core::ffi::c_int::try_from(std::mem::size_of::<nvme_security_receive_args>())
+                    .unwrap(),
+            fd: 0, // Set at transport level
+            nsid: nsid,
+            nssf: 0, //RSVD
+            spsp0: 0,
+            spsp1: 0, // RSVD
+            secp: 0,
+            al: 0,
+            data_len: 0,
+            data: dptr.as_mut_ptr() as *mut c_void,
+            timeout: 0, // Set at transport
+            result: ptr::null_mut(),
+        };
+
+        let mut transport_message_len: usize = dptr.len() as usize;
+        let mut allocation_len: usize = 0;
+
+        let rc = unsafe {
+            libspdm_transport_storage_encode_management_cmd(
+                u8::try_from(LIBSPDM_STORAGE_CMD_DIRECTION_IF_RECV).unwrap(),
+                SpdmOperationCodes::SpdmStorageDiscovery as u8,
+                conn_id,
+                &mut transport_message_len,
+                &mut allocation_len,
+                dptr.as_mut_ptr() as *mut c_void,
+            )
+        };
+
+        if !spdm::LibspdmReturnStatus::libspdm_status_is_success(rc) {
+            panic!("libspdm failed to encode transport: {:x}", rc);
+        }
+
+        let trans_hdr = unsafe { *(dptr.as_mut_ptr() as *mut storage_spdm_transport_header) };
+
+        // Update based on libspdm encoded data
+        args.secp = trans_hdr.security_protocol;
+        let spsp = u16::from_le(trans_hdr.security_protocol_specific);
+        args.spsp0 = (spsp & 0xFF) as u8;
+        args.spsp1 = (spsp >> 8) as u8;
+
+        let transport_message_len = u32::from_le(trans_hdr.length);
+        assert!(args.spsp0 != 0);
+        assert!(args.spsp1 == 0);
+        assert!(transport_message_len as usize <= dptr.len());
+        assert!(transport_message_len != 0);
+        assert!(transport_message_len != 0);
+
+        args.al = std::cmp::max(allocation_len as u32, LIBNVME_RECV_ARG_MIN_AL_LEN as u32);
+        args.data_len = std::cmp::max(transport_message_len, LIBNVME_RECV_ARG_MIN_AL_LEN as u32);
+
+        Ok(args)
+    }
+}
+
+/// # Summary
+///
+/// Fetch supported security protocols from the NVMe device. This should be used
+/// prior to `register_device()` to ensure that the NVMe controller supports
+/// SPDM over storage.
+///
+/// # Note
+///
+/// This function operates independantely, that is, when it returns it closes
+/// the `fd` associated with the controller.
+///
+/// # Parameter
+///
+/// * `path: path to the device
+/// * `nsid`: name-space identifier
+///
+/// # Returns
+///
+/// Ok(()), on success
+/// Err(Errno::ENOTSUP), is DMTF SPDM is not supported
+pub fn nvme_get_sec_info(path: &String, nsid: u32) -> Result<(), Errno> {
+    let mut dev = NvmeDev::new(path, nsid, OFlag::O_EXCL | OFlag::O_RDONLY)?;
+    let mut dptr = vec![0; 64];
+
+    let mut sec_recv_args =
+        NvmeSecRecvCmds::gen_libspdm_encoded_discovery_request_args(&mut dptr, nsid)?;
+
+    debug!(
+        "Security Receive Command Discovery Request: {:?}",
+        sec_recv_args
+    );
+
+    // Receive the discovery response
+    if dev.nvme_sec_recv(&mut sec_recv_args, 0).is_err() {
+        return Err(Errno::EIO);
+    }
+
+    info!("--- SPDM Storage Discovery Start ---");
+
+    let data_len = u16::from_be_bytes(dptr[..2].try_into().unwrap());
+    let storage_binding_version = u16::from_be_bytes(dptr[2..4].try_into().unwrap());
+    let max_connection_id = dptr[4] & 0b11;
+    let supported_operations = dptr[8];
+
+    info!(" Available bytes in SPDM Storage Data: {:}", data_len);
+    info!(" Storage Binding Version: 0x{:x}", storage_binding_version);
+    info!(" Max num connections: {:}", max_connection_id);
+    if max_connection_id == 0 {
+        info!("     - A value of 0 indicates 1 connection");
+    }
+    info!(" Supported Opertations:");
+
+    if supported_operations & (1 << SpdmOperationCodes::SpdmStorageDiscovery as u8) != 0 {
+        info!("     SpdmStorageDiscovery - Supported");
+    } else {
+        error!("    Device does not support mandatory SpdmStorageDiscovery");
+        return Err(Errno::ENOTSUP);
+    }
+
+    if supported_operations & (1 << SpdmOperationCodes::SpdmStorageMessage as u8) != 0 {
+        info!("     SpdmStorageMessage - Supported");
+    } else {
+        error!("    Device does not support mandatory SpdmStorageMessage");
+        return Err(Errno::ENOTSUP);
+    }
+
+    if supported_operations & (1 << SpdmOperationCodes::SpdmStoragePendingInfo as u8) != 0 {
+        info!("     SpdmStoragePendingInfo - Supported");
+    }
+    if supported_operations & (1 << SpdmOperationCodes::SpdmStorageSecMessage as u8) != 0 {
+        info!("     SpdmStorageSecMessage - Supported");
+    }
+
+    info!("--- SPDM Storage Discovery Response End ---");
+
+    Ok(())
+}

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -407,6 +407,7 @@ pub fn register_device(
                     Some(qemu_receive_message_mctp),
                 );
             }
+            TransportLayer::Storage => todo!(),
         }
         io_buffers::libspdm_setup_io_buffers(
             context,

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -17,15 +17,65 @@ use std::net::{TcpListener, TcpStream};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::Mutex;
 use std::time::Duration;
+use storage_standards::{AtaStatusErr, NvmeCmdStatus, ScsiAsc, SpdmOperationCodes};
 
 const SEND_RECEIVE_BUFFER_LEN: usize = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
 
 const SOCKET_SPDM_COMMAND_NORMAL: u32 = 0x01;
+const SOCKET_SPDM_STORAGE_IF_SEND: u32 = 0x02;
+const SOCKET_SPDM_STORAGE_IF_RECV: u32 = 0x03;
+const SOCKET_SPDM_STORAGE_ACK_STATUS: u32 = 0x04;
 
 const SOCKET_TRANSPORT_TYPE_MCTP: u32 = 0x01;
 const SOCKET_TRANSPORT_TYPE_PCI_DOE: u32 = 0x02;
 
 static CLIENT_CONNECTION: Lazy<Mutex<Option<TcpStream>>> = Lazy::new(|| Mutex::new(None));
+const SOCKET_TRANSPORT_TYPE_SCSI: u32 = 0x03;
+const SOCKET_TRANSPORT_TYPE_NVME: u32 = 0x04;
+const SOCKET_TRANSPORT_TYPE_ATA: u32 = 0x05;
+
+pub fn qemu_socket_transport_is_valid(spdm_trans: u32) -> bool {
+    if !(spdm_trans == SOCKET_TRANSPORT_TYPE_PCI_DOE
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_MCTP
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_SCSI
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_NVME
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_ATA)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_spdm_cmd_is_valid(spdm_cmd: u32) -> bool {
+    if !(spdm_cmd == SOCKET_SPDM_COMMAND_NORMAL
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_SEND
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_RECV
+        || spdm_cmd == SOCKET_SPDM_STORAGE_ACK_STATUS)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_storage_transport_is_valid(spdm_trans: u32) -> bool {
+    if !(spdm_trans == SOCKET_TRANSPORT_TYPE_SCSI
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_NVME
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_ATA)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_storage_cmd_is_valid(spdm_cmd: u32) -> bool {
+    if !(spdm_cmd == SOCKET_SPDM_STORAGE_IF_SEND
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_RECV
+        || spdm_cmd == SOCKET_SPDM_STORAGE_ACK_STATUS)
+    {
+        return false;
+    }
+    true
+}
 
 /// # Summary
 ///
@@ -345,6 +395,736 @@ unsafe extern "C" fn qemu_receive_message_mctp(
 
 /// # Summary
 ///
+/// Get the next incoming storage command from the requester through QEMU.
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `msg_len`: On return, number of bytes received
+/// * `msg_in`: Data buffer to capture incoming command (this must be of sufficient length)
+///
+/// # Returns
+///
+/// Storage Command, only valid types are IF_RECV/IF_SEND.
+pub fn qemu_get_next_storage_cmd(
+    stream: &mut TcpStream,
+    msg_len: &mut usize,
+    msg_in: &mut [u8],
+) -> Option<(u32, u32)> {
+    debug!("Receiving message");
+    // QEMU sends additional information regarding the message
+    // Read them here so they don't go into the SPDM message buffer.
+    let mut buf: [u8; 4] = [0; 4];
+
+    // SPDM Command
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+    let cmd = u32::from_be_bytes(buf);
+    assert!(qemu_socket_storage_cmd_is_valid(cmd));
+
+    // Transport Type
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+    let transport = u32::from_be_bytes(buf);
+    assert!(qemu_socket_storage_transport_is_valid(transport));
+
+    // Receive Size
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+
+    let mut read_len = stream.read(msg_in);
+    while read_len.is_err() {
+        read_len = stream.read(msg_in);
+    }
+    let read_len = read_len.unwrap();
+
+    debug!("SPDM Transport Receive: {:x?}", &msg_in[..read_len]);
+
+    if read_len == 0 {
+        // when read() return 0, the two likely cases are:
+        // 1. socket shut down correctly
+        // 2. reader has reached its “end of file” and will likely no longer be
+        //    able to produce bytes
+        warn!("Connection dropped to client, exiting...");
+        std::process::exit(0);
+    }
+
+    assert!(read_len != 0);
+
+    *msg_len = read_len;
+
+    Some((cmd, transport))
+}
+
+/// # Summary
+///
+/// QEMU waits for a status reply for and IF_RECV/IF_SEND that shall be forwarded
+/// back to the requester. This functions acks with `storage_cmd_status`
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+/// * `storage_cmd_status`: Message status type
+///
+/// # Returns
+///
+/// Ok(()) on success
+pub fn qemu_socket_storage_ack_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+    storage_cmd_status: u16,
+) -> Result<(), Errno> {
+    if !qemu_socket_spdm_cmd_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    if !qemu_socket_storage_transport_is_valid(spdm_trans) {
+        return Err(Errno::EINVAL);
+    }
+
+    // Write out the data
+    assert_eq!(stream.write(&spdm_cmd.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(stream.write(&spdm_trans.to_be().to_ne_bytes()).unwrap(), 4);
+
+    // We are only writing back the cmd status
+    let tx_len = core::mem::size_of::<u16>();
+    assert_eq!(
+        stream
+            .write(&(u32::try_from(tx_len).unwrap()).to_be().to_ne_bytes())
+            .unwrap(),
+        4
+    );
+
+    assert_eq!(
+        stream
+            .write(&storage_cmd_status.to_be().to_ne_bytes())
+            .unwrap(),
+        2
+    );
+    stream.flush().unwrap();
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// Write an response message back to QEMU
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+/// * `msg_size`: size of message in bytes
+/// * `msg_buf`: message data buffer
+///
+/// # Returns
+///
+/// Ok(()) on success
+/// Err(Errno) on any failures
+pub fn qemu_socket_xfer_to_requester(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+    msg_size: u32,
+    msg_buf: &[u8],
+) -> Result<(), Errno> {
+    if !qemu_socket_spdm_cmd_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    if !qemu_socket_transport_is_valid(spdm_trans) {
+        return Err(Errno::EINVAL);
+    }
+
+    if msg_size as usize > msg_buf.len() {
+        return Err(Errno::EINVAL);
+    }
+
+    // Write out the data
+    assert_eq!(stream.write(&spdm_cmd.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(stream.write(&spdm_trans.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(
+        stream
+            .write(&(u32::try_from(msg_size).unwrap()).to_be().to_ne_bytes())
+            .unwrap(),
+        4
+    );
+
+    stream.write_all(msg_buf).unwrap();
+    stream.flush().unwrap();
+
+    Ok(())
+}
+
+pub fn qemu_ack_invalid_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+) -> Result<(), Errno> {
+    if !qemu_socket_storage_transport_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    match spdm_trans {
+        SOCKET_TRANSPORT_TYPE_NVME => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                NvmeCmdStatus::NvmeInvalidFieldInCmd as u16 | NvmeCmdStatus::NvmeDoNotRetry as u16,
+            )
+            .unwrap();
+            warn!(
+                "Acked bad message with NVME status: {:?} & {:?} - Code: 0x{:x}",
+                NvmeCmdStatus::NvmeInvalidFieldInCmd,
+                NvmeCmdStatus::NvmeDoNotRetry,
+                NvmeCmdStatus::NvmeInvalidFieldInCmd as u16 | NvmeCmdStatus::NvmeDoNotRetry as u16
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_SCSI => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                ScsiAsc::InvalidFieldInCdb as u16,
+            )
+            .unwrap();
+
+            warn!(
+                "Acked bad message with SCSI ASC: {:?}",
+                ScsiAsc::InvalidFieldInCdb
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_ATA => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                AtaStatusErr::InvalidCommand as u16,
+            )
+            .unwrap();
+
+            warn!(
+                "Acked bad message with ATA Status {:?} | ATA Error {:?}",
+                (AtaStatusErr::InvalidCommand as u16) >> 8,
+                (AtaStatusErr::InvalidCommand as u16) & 0xFF
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// QEMU waits for a status reply for and IF_RECV/IF_SEND that shall be forwarded
+/// back to the requester. This functions acks with NVMe CQE Success.
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+///
+/// # Returns
+///
+/// Ok(()) on success
+/// Err(Errno) on any failures
+pub fn qemu_ack_valid_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+) -> Result<(), Errno> {
+    if !qemu_socket_storage_transport_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    match spdm_trans {
+        SOCKET_TRANSPORT_TYPE_NVME => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                NvmeCmdStatus::NvmeSuccess as u16,
+            )
+            .unwrap();
+
+            debug!(
+                "Acked message with NVME status: {:?}",
+                NvmeCmdStatus::NvmeSuccess,
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_SCSI => {
+            qemu_socket_storage_ack_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, spdm_trans, 0)
+                .unwrap();
+            debug!("Acked message with status OK");
+        }
+        SOCKET_TRANSPORT_TYPE_ATA => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                AtaStatusErr::Success as u16,
+            )
+            .unwrap();
+            debug!("Acked message with status OK");
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+struct QemuStorageTransportHeaderCompact {
+    spsp0_op: u8,
+    length: u32,
+}
+
+fn qemu_storage_decode_transport_header(
+    transport_msg_len: usize,
+    transport_msg: &mut [u8],
+) -> Result<QemuStorageTransportHeaderCompact, ()> {
+    let mut transport_cmd = 0;
+    // Allocation length for an IF_RECV, Transfer length for an IF_SEND
+    let mut len: u32 = 0;
+    let rc = unsafe {
+        libspdm_transport_storage_decode_management_cmd(
+            transport_msg_len,
+            transport_msg.as_mut_ptr() as *mut c_void,
+            &mut transport_cmd,
+            &mut len,
+        )
+    };
+
+    if !spdm::LibspdmReturnStatus::libspdm_status_is_success(rc) {
+        error!(
+            "Malformed Storage Transport header: {:x?}",
+            &transport_msg[..transport_msg_len]
+        );
+        error!("libspdm err: 0x{:X}", rc);
+        return Err(());
+    }
+
+    Ok(QemuStorageTransportHeaderCompact {
+        spsp0_op: transport_cmd,
+        length: len,
+    })
+}
+
+/// # Summary
+///
+/// Sends message to the QEMU by writing the
+/// `message_ptr` data to the TCP stream used by QEMU. This also writes the
+/// additional information expected by QEMU.
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `timeout`: Transaction timeout
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn qemu_send_message_storage(
+    _context: *mut c_void,
+    libspdm_message_size: usize,
+    libspdm_message_ptr: *const c_void,
+    timeout: u64,
+) -> u32 {
+    debug!(
+        "about to send a message of len: {}bytes",
+        libspdm_message_size
+    );
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let message = libspdm_message_ptr as *const u8;
+            let libspdm_msg_buf = unsafe { from_raw_parts(message, libspdm_message_size) };
+
+            if timeout == 0 {
+                stream
+                    .set_write_timeout(None)
+                    .expect("Couldn't set write timeout");
+            } else {
+                stream
+                    .set_write_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set write timeout");
+            }
+            // TODO: Is there a better way to capture incoming commands?
+            //       We are using a bunch of memory here.
+            let mut incoming_msg: [u8; SEND_RECEIVE_BUFFER_LEN] = [0; SEND_RECEIVE_BUFFER_LEN];
+            let mut incoming_msg_len = 0;
+
+            loop {
+                let (cmd, trans_type) =
+                    qemu_get_next_storage_cmd(stream, &mut incoming_msg_len, &mut incoming_msg)
+                        .unwrap();
+                let hdr = qemu_storage_decode_transport_header(incoming_msg_len, &mut incoming_msg);
+                if hdr.is_err() {
+                    qemu_ack_invalid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                        .expect("Failed to ack message");
+                    continue;
+                }
+                let hdr = hdr.unwrap();
+                match cmd {
+                    SOCKET_SPDM_STORAGE_IF_SEND => {
+                        // We have an SPDM response to send, but the requester has sent
+                        // us another IF_SEND instead of receiving our pending response
+                        // with IF_RECV. The only valid spdm_storage_operations are
+                        // discovery and pending_info at in this context.
+
+                        // Ack the incoming message if valid
+                        match SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmOperationCodes::SpdmStorageDiscovery => {
+                                debug!(
+                                    "Storage Transport Discovery Command - Nothing to do (IF_SEND)"
+                                );
+                            }
+                            SpdmOperationCodes::SpdmStoragePendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command - Nothing to do (IF_SEND)");
+                                debug!(
+                                    "    - Pending response length: {:} bytes",
+                                    libspdm_message_size
+                                );
+                            }
+                            SpdmOperationCodes::SpdmStorageMessage
+                            | SpdmOperationCodes::SpdmStorageSecMessage => {
+                                error!(
+                                    "Unexpected IF_SEND with {:?}",
+                                    SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap()
+                                );
+                                qemu_ack_invalid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+                                continue;
+                            }
+                        }
+                        // Message was valid, but we had no work to do
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+                    }
+                    SOCKET_SPDM_STORAGE_IF_RECV => {
+                        // This IF_RECV could be for the SPDM response message or a transport
+                        // command
+                        if incoming_msg_len < LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize {
+                            error!("Malformed transport header for IF_RECV!");
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        let mut transport_msg_len = 32;
+                        let mut transport_msg: [u8; 32] = [0; 32];
+
+                        match SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmOperationCodes::SpdmStorageDiscovery => {
+                                debug!("Handling Storage Transport Discovery Command (IF_RECV)");
+                                assert!(spdm::LibspdmReturnStatus::libspdm_status_is_success(
+                                    libspdm_transport_storage_encode_discovery_response(
+                                        &mut transport_msg_len,
+                                        transport_msg.as_mut_ptr() as *mut c_void,
+                                    )
+                                ));
+                            }
+                            SpdmOperationCodes::SpdmStoragePendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command (IF_RECV)");
+                                debug!(
+                                    "    - Pending response length: {:} bytes",
+                                    libspdm_message_size
+                                );
+                                assert!(spdm::LibspdmReturnStatus::libspdm_status_is_success(
+                                    libspdm_transport_storage_encode_pending_info_response(
+                                        &mut transport_msg_len,
+                                        transport_msg.as_mut_ptr() as *mut c_void,
+                                        true,
+                                        u32::try_from(libspdm_message_size).unwrap(),
+                                    )
+                                ));
+                            }
+                            SpdmOperationCodes::SpdmStorageMessage
+                            | SpdmOperationCodes::SpdmStorageSecMessage => {
+                                if (hdr.length as usize) < libspdm_message_size {
+                                    error!(
+                                        "Requester allocation length too small to receive {:?} message.  Minimum required {:}, Got {:}",
+                                        SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap(),
+                                        libspdm_message_size,
+                                        hdr.length
+                                    );
+                                    qemu_ack_valid_msg(
+                                        stream,
+                                        SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                        trans_type,
+                                    )
+                                    .expect("Failed to ack message");
+                                    continue;
+                                }
+                                qemu_ack_valid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+
+                                qemu_socket_xfer_to_requester(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_IF_RECV,
+                                    trans_type,
+                                    u32::try_from(libspdm_message_size).unwrap(),
+                                    &libspdm_msg_buf,
+                                )
+                                .expect("failed to write response to requester");
+
+                                debug!("SPDM Send: {:x?}", libspdm_msg_buf);
+                                break;
+                            }
+                        }
+
+                        assert!(transport_msg_len <= transport_msg.len());
+
+                        // A valid transport command request, let's send the response
+                        // generated
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        qemu_socket_xfer_to_requester(
+                            stream,
+                            SOCKET_SPDM_STORAGE_IF_RECV,
+                            trans_type,
+                            u32::try_from(transport_msg_len).unwrap(),
+                            &transport_msg[..transport_msg_len],
+                        )
+                        .expect("failed to write response to requester");
+                    }
+                    _ => unreachable!("Undefined qemu transport management command"),
+                }
+            }
+        }
+        None => {
+            unreachable!("Socket stream lost")
+        }
+    }
+    0
+}
+
+/// # Summary
+///
+/// Receives a message from QEMU into buffer pointed to by
+/// the `message_ptr`. This may block until the socket has data ready. This will
+/// also fetch the additional message data (non-spdm) sent from QEMU.
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `SEND_RECEIVE_BUFFER_LEN` to capture the received bytes.
+/// * `timeout`: Transaction timeout
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn qemu_receive_message_storage(
+    _context: *mut c_void,
+    libspdm_message_size: *mut usize,
+    libspdm_msg_buf_ptr: *mut *mut c_void,
+    timeout: u64,
+) -> u32 {
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let libspdm_message = *libspdm_msg_buf_ptr as *mut u8;
+            // We are using this to cache any incoming temporary data,
+            // When an SPDM message is received, it will be overwritten with that data
+            // before being passed back to libspdm.
+            let mut libspdm_message_buf =
+                from_raw_parts_mut(libspdm_message, SEND_RECEIVE_BUFFER_LEN);
+
+            if timeout == 0 {
+                stream
+                    .set_read_timeout(None)
+                    .expect("Couldn't set read timeout");
+            } else {
+                stream
+                    .set_read_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set read timeout");
+            }
+
+            let mut incoming_msg_len = 0;
+
+            loop {
+                let (cmd, trans_type) = qemu_get_next_storage_cmd(
+                    stream,
+                    &mut incoming_msg_len,
+                    &mut libspdm_message_buf,
+                )
+                .unwrap();
+                let hdr = qemu_storage_decode_transport_header(
+                    incoming_msg_len,
+                    &mut libspdm_message_buf,
+                );
+                if hdr.is_err() {
+                    qemu_ack_invalid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                        .expect("Failed to ack message");
+                    continue;
+                }
+                let hdr = hdr.unwrap();
+                match cmd {
+                    SOCKET_SPDM_STORAGE_IF_SEND => {
+                        // Contextually, we are expecting an IF_SEND with a storage/secure msg.
+                        // But we could also get discovery/pending_info here.
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        match SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmOperationCodes::SpdmStorageDiscovery => {
+                                debug!(
+                                    "Storage Transport Discovery Command - Nothing to do (IF_SEND)"
+                                );
+                                continue;
+                            }
+                            SpdmOperationCodes::SpdmStoragePendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command - Nothing to do (IF_SEND)");
+                                debug!("    - No pending response!");
+                                continue;
+                            }
+                            SpdmOperationCodes::SpdmStorageMessage
+                            | SpdmOperationCodes::SpdmStorageSecMessage => {
+                                // Received an actual SPDM message
+                                *libspdm_message_size = hdr.length as usize;
+                                info!(
+                                    "SPDM Received {:?}: {:x?}",
+                                    SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap(),
+                                    &libspdm_message_buf[..(hdr.length as usize)]
+                                );
+                                // The data was received into the memory allocated by libspdm
+                                // no more work to do.
+                                break;
+                            }
+                        };
+                    }
+                    SOCKET_SPDM_STORAGE_IF_RECV => {
+                        // We have no data to return in this context, an IF_RECV should
+                        // only mean that it was a transport Discovery/Pending Info
+                        // command.
+                        let mut transport_msg_len: usize = 32;
+                        let mut transport_msg: [u8; 32] = [0; 32];
+
+                        if (hdr.length as usize) < transport_msg_len {
+                            error!(
+                                "Requester allocation length too small to receive {:?} message. Minimum required {:?}, Got {:?}",
+                                SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap(),
+                                transport_msg_len,
+                                hdr.length
+                            );
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        let rc = match SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmOperationCodes::SpdmStorageDiscovery => {
+                                debug!("Handling Storage Transport Discovery Command (IF_RECV)");
+                                libspdm_transport_storage_encode_discovery_response(
+                                    &mut transport_msg_len,
+                                    transport_msg.as_mut_ptr() as *mut c_void,
+                                )
+                            }
+                            SpdmOperationCodes::SpdmStoragePendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command (IF_RECV)");
+                                debug!("    - No pending response!");
+                                libspdm_transport_storage_encode_pending_info_response(
+                                    &mut transport_msg_len,
+                                    transport_msg.as_mut_ptr() as *mut c_void,
+                                    false,
+                                    0,
+                                )
+                            }
+                            _ => {
+                                error!(
+                                    "Unexpected IF_RECV with {:?}",
+                                    SpdmOperationCodes::try_from(hdr.spsp0_op).unwrap()
+                                );
+                                qemu_ack_invalid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+                                continue;
+                            }
+                        };
+
+                        if !spdm::LibspdmReturnStatus::libspdm_status_is_success(rc) {
+                            error!(
+                                "Failed to generate transport response, libspdm err: {:x}",
+                                rc
+                            );
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        assert!(transport_msg_len <= transport_msg.len());
+
+                        // A valid transport command request, let's send the response
+                        // generated
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        qemu_socket_xfer_to_requester(
+                            stream,
+                            SOCKET_SPDM_STORAGE_IF_RECV,
+                            trans_type,
+                            u32::try_from(transport_msg_len).unwrap(),
+                            &transport_msg[..transport_msg_len],
+                        )
+                        .expect("Failed to write transport response to requester");
+                    }
+                    _ => unreachable!("Undefined qemu transport management command"),
+                }
+            }
+        }
+        None => {
+            unreachable!("Socket stream lost")
+        }
+    }
+    0
+}
+
+/// # Summary
+///
 /// Registers the SPDM `context` for a `qemu_server` backend.
 ///
 /// # Parameter
@@ -407,7 +1187,13 @@ pub fn register_device(
                     Some(qemu_receive_message_mctp),
                 );
             }
-            TransportLayer::Storage => todo!(),
+            TransportLayer::Storage => {
+                libspdm_register_device_io_func(
+                    context,
+                    Some(qemu_send_message_storage),
+                    Some(qemu_receive_message_storage),
+                );
+            }
         }
         io_buffers::libspdm_setup_io_buffers(
             context,

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -1,0 +1,845 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2024, Western Digital Corporation or its affiliates.
+
+//! This file provides support for SPDM interfacing to a SCSI device
+//!
+//! SAFETY: This file includes a lot of unsafe Rust.
+//! If libspdm behaves in a manor we don't expect this will be very bad,
+//! so we are trusting libspdm here.
+//!
+
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2022, Western Digital Corporation or its affiliates.
+
+//! SAFETY: This file includes a lot of unsafe Rust.
+//! If libspdm behaves in a manor we don't expect this will be very bad,
+//! so we are trusting libspdm here.
+//!
+use crate::*;
+use core::ffi::c_void;
+use core::ptr;
+use libspdm::spdm::LIBSPDM_MAX_SPDM_MSG_SIZE;
+use nix::errno::Errno;
+use nix::fcntl::{open, OFlag};
+use nix::libc::ioctl;
+use nix::sys::stat::{stat, Mode, SFlag};
+use nix::unistd::close;
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::sync::Mutex;
+
+const SEND_RECEIVE_BUFFER_LEN: usize = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
+// Global reference to the device instance to reduce sys-call overhead.
+// The execution context is already unsafe, what's the worst that could happen!
+static SCSI_DEV: Lazy<Mutex<Option<BlkDev>>> = Lazy::new(|| Mutex::new(None));
+
+const SG_SENSE_MAX_LENGTH: u8 = 64;
+const SG_BUF_MAX_SIZE: u32 = SEND_RECEIVE_BUFFER_LEN as u32;
+const SG_CDB_MAX_SIZE: u8 = 32;
+const SG_CDB_DEFAULT_SIZE: u8 = 16;
+const SCSI_SEC_IN_OUT_CDB_LEN: usize = 12;
+
+/*
+ * Status codes.
+ */
+const _SG_CHECK_CONDITION: u8 = 0x02;
+
+/*
+ * Host status codes.
+ */
+const SG_DID_OK: u16 = 0x00; /* No error */
+const _SG_DID_NO_CONNECT: u16 = 0x01; /* Couldn't connect before timeout period */
+const _SG_DID_BUS_BUSY: u16 = 0x02; /* BUS stayed busy through time out period */
+const SG_DID_TIME_OUT: u16 = 0x03; /* Timed out for other reason */
+const _SG_DID_BAD_TARGET: u16 = 0x04; /* Bad target, device not responding? */
+const _SG_DID_ABORT: u16 = 0x05; /* Told to abort for some other reason. */
+const _SG_DID_PARITY: u16 = 0x06; /* Parity error. */
+const _SG_DID_ERROR: u16 = 0x07; /* Internal error detected in the host adapter. */
+const _SG_DID_RESET: u16 = 0x08; /* The SCSI bus (or this device) has been reset. */
+const _SG_DID_BAD_INTR: u16 = 0x09; /* Got an unexpected interrupt */
+const _SG_DID_PASSTHROUGH: u16 = 0x0a; /* Forced command past mid-layer. */
+const _SG_DID_SOFT_ERROR: u16 = 0x0b; /* The low level driver wants a retry. */
+
+/*
+ * Driver status codes.
+ */
+const _SG_DRIVER_OK: u16 = 0x00;
+const _SG_DRIVER_BUSY: u16 = 0x01;
+const _SG_DRIVER_SOFT: u16 = 0x02;
+const _SG_DRIVER_MEDIA: u16 = 0x03;
+const _SG_DRIVER_ERROR: u16 = 0x04;
+const _SG_DRIVER_INVALID: u16 = 0x05;
+const _SG_DRIVER_TIMEOUT: u16 = 0x06;
+const _SG_DRIVER_HARD: u16 = 0x07;
+const SG_DRIVER_SENSE: u16 = 0x08;
+const SG_DRIVER_STATUS_MASK: u16 = 0x0f;
+
+/*
+* Device Flags
+*/
+const DEV_VENDOR_LEN: usize = 9;
+const DEV_ID_LEN: usize = 17;
+const DEV_REV_LEN: usize = 5;
+
+#[allow(dead_code)]
+struct SgCmd {
+    bufsz: u32,
+    io_hdr: sg_io_hdr_t,
+    sense_key: u8,
+    asc_ascq: u16,
+    cmdp: Vec<u8>,
+    dxferp: Vec<u8>,
+    sbp: Vec<u8>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct BlkDev {
+    fd: Option<i32>,
+    flags: OFlag,
+}
+
+impl BlkDev {
+    /// # Summary
+    ///
+    /// Create and return device structure to the SCSI device pointed to by
+    /// @path, where the underlying fd is opened with @flags.
+    ///
+    /// # Parameter
+    ///
+    /// * `path: path to the device
+    /// * `flags`: flags for the device to use on `open()`
+    ///
+    /// # Returns
+    ///
+    /// Err(Errno) on failure
+    /// Ok(BlkDev) on success, containing the file-descriptor for the device
+    fn new(path: &String, flags: OFlag) -> Result<BlkDev, Errno> {
+        let path = Path::new(path);
+        let st = stat(path);
+        info!("Getting device info for: {:?}", path);
+        if let Err(e) = st {
+            error!("Failed to get stat at {:?}: {}:?", path, e);
+            return Err(e);
+        }
+
+        let st = st.unwrap();
+        let st_mode = st.st_mode;
+
+        if !((SFlag::S_IFMT.bits() & st_mode) == SFlag::S_IFCHR.bits())
+            && !((SFlag::S_IFMT.bits() & st_mode) == SFlag::S_IFBLK.bits())
+        {
+            error!("Invalid device file {:?}", path);
+            return Err(Errno::EIO);
+        }
+
+        match open(path, flags, Mode::S_IRWXU) {
+            Ok(fd) => {
+                return Ok(BlkDev {
+                    fd: Some(fd),
+                    flags: flags,
+                });
+            }
+            Err(e) => {
+                error!("Failed to open file {:?}: {:?}", path, e);
+                return Err(e);
+            }
+        }
+    }
+}
+
+impl Drop for BlkDev {
+    /// # Summary
+    ///
+    /// Close the underlying file-descriptor when this instance goes out of scope
+    fn drop(&mut self) {
+        if let Some(fd) = self.fd {
+            close(fd).expect("failed to close device fd");
+            return;
+        }
+        unreachable!("device fd was not set!");
+    }
+}
+
+/// SCSI Primary Commands
+pub enum CmdType {
+    /// Inquire the device server for basic device information
+    Inquiry,
+    /// Requests the device server to return security protocol information
+    /// For SPDM: this is IF-RECV:
+    /// "Generic term for a security related command that transfers data
+    /// from the target to the initiator. For NVMe, this is Security
+    /// Receive. For SAS, this is SECURITY PROTOCOL IN. For SATA, this is
+    /// TRUSTED RECEIVE and TRUSTED RECEIVE DMA." -
+    /// https://github.com/DMTF/SPDM-WG/blob/master/docs/DSP0286/DSP0286.md#SPC-6
+    SecurityProtocolIn,
+    /// Requests the device server to process the specified parameter
+    /// list using the specified security protocol. For SPDM:
+    /// this is IF-SEND: "Generic term for a security related command that
+    /// transfers data from the initiator to the target.
+    /// For NVMe, this is Security Send. For SAS, this is
+    /// SECURITY PROTOCOL OUT. For SATA, this is TRUSTED SEND and
+    /// TRUSTED SEND DMA." -
+    /// https://github.com/DMTF/SPDM-WG/blob/master/docs/DSP0286/DSP0286.md#SPC-6
+    SecurityProtocolOut,
+}
+
+impl From<CmdType> for u8 {
+    fn from(c: CmdType) -> Self {
+        match c {
+            CmdType::Inquiry => 0x12,
+            CmdType::SecurityProtocolIn => 0xA2,
+            CmdType::SecurityProtocolOut => 0xB5,
+        }
+    }
+}
+
+/// Relevant Security Protocols as specified in Working Draft SCSI Primary
+/// Commands - 6 (SPC-6)
+#[derive(Debug, PartialEq)]
+pub enum SpcSecurityProtocols {
+    SecurityProtocolInformation,
+    DmtfSpdm,
+}
+
+impl From<SpcSecurityProtocols> for u8 {
+    fn from(c: SpcSecurityProtocols) -> Self {
+        match c {
+            SpcSecurityProtocols::SecurityProtocolInformation => 0x00,
+            SpcSecurityProtocols::DmtfSpdm => 0xE8,
+        }
+    }
+}
+
+impl TryFrom<u8> for SpcSecurityProtocols {
+    type Error = ();
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0x00 => Ok(SpcSecurityProtocols::SecurityProtocolInformation),
+            0xE8 => Ok(SpcSecurityProtocols::DmtfSpdm),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SgCmd {
+    fn new(cdb_len: u8, direction: i32, bufsz: u32) -> Result<SgCmd, Errno> {
+        if bufsz > SG_BUF_MAX_SIZE {
+            return Err(Errno::EINVAL);
+        }
+        /* Setup SGIO header. sg_io_hdr_t has no Default type but can be zero
+         * initialize and update it's internal references later.
+         */
+        let mut sg_io_hdr: sg_io_hdr_t = unsafe { std::mem::zeroed() };
+        // 'S' for SCSI generic/SG (required)
+        sg_io_hdr.interface_id = b'S' as i32;
+        sg_io_hdr.timeout = 30000;
+        // At tail
+        sg_io_hdr.flags = 0x10;
+
+        if cdb_len != 0 {
+            if cdb_len > SG_CDB_MAX_SIZE {
+                return Err(Errno::E2BIG);
+            }
+            sg_io_hdr.cmd_len = cdb_len;
+        } else {
+            sg_io_hdr.cmd_len = SG_CDB_DEFAULT_SIZE;
+        }
+
+        sg_io_hdr.dxfer_direction = direction;
+        sg_io_hdr.dxfer_len = bufsz;
+        sg_io_hdr.mx_sb_len = SG_SENSE_MAX_LENGTH;
+
+        let mut sg_cmd = SgCmd {
+            bufsz,
+            io_hdr: sg_io_hdr,
+            sense_key: 0,
+            asc_ascq: 0,
+            // Must be heap allocated for FFI compatibility with C
+            // io_hdr.cmdp = cdb
+            cmdp: vec![0; SG_CDB_MAX_SIZE as usize],
+            // io_hdr.dxferp = buf
+            dxferp: vec![0; SG_BUF_MAX_SIZE as usize],
+            // io_hdr.sbp = sense_buf
+            sbp: vec![0; SG_SENSE_MAX_LENGTH as usize],
+        };
+
+        sg_cmd.set_io_buffer_ptrs();
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an Inquiry commands to retrieve basic information from the
+    /// device.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialised command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_dev_inquiry_info(cdb_len: u8, direction: i32, bufsz: u16) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz as u32)?;
+
+        // Setup Inquiry Command
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::Inquiry.into();
+        // Allocation Bytes
+        sg_cmd.cmdp[3..=4].copy_from_slice(&(bufsz.to_be_bytes()));
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an IF-SEND/SECURITY_IN command with the subcommand argument
+    /// specified to fetch the list of supported security protocols from the
+    /// device.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialised command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_security_protocols_list(
+        cdb_len: u8,
+        direction: i32,
+        bufsz: u32,
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+
+        // Setup Security In Command for protocol inquiry
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolIn.into();
+        // Security Protocol
+        sg_cmd.cmdp[1] = SpcSecurityProtocols::SecurityProtocolInformation.into();
+        // Security Protocol Specific
+        // https://github.com/DMTF/SPDM-WG/blob/master/docs/DSP0286/DSP0286.md#command-management
+        // Table: 4 and 5 in Command management.
+        // This should be updated at the transport level, at this stage
+        // we don't know the message type/connection type.
+        sg_cmd.cmdp[2] = 0x00; // Operation - TBD (unknown at this stage)
+        sg_cmd.cmdp[3] = 0x00; // Reserved
+        sg_cmd.cmdp[4] = 0x00; // Not using increments of 512B in allocation length
+                               // Allocation Length Bytes
+        sg_cmd.cmdp[6..=9].copy_from_slice(&((bufsz as u32).to_be_bytes()));
+        // Control, TODO: Don't need (?)
+        sg_cmd.cmdp[11] = 0x00;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Use the transport header generated by `libspdm` to generate a SCSI
+    /// Security Protocol Out command.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    /// * `header`: libspdm encoded spdm storage transport header
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialised command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_libspdm_request(
+        cdb_len: u8,
+        direction: i32,
+        bufsz: u32,
+        header: &mut [u8; LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize],
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+        let hdr = unsafe { *(header.as_mut_ptr() as *mut storage_spdm_transport_header) };
+
+        // Setup Security Out Command for SPDM request [IF-SEND]
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolOut.into();
+        sg_cmd.cmdp[1] = hdr.security_protocol;
+        // All fields in the storage transport are little endian
+        let spsp = u16::from_le(hdr.security_protocol_specific);
+        sg_cmd.cmdp[2..=3].copy_from_slice(&spsp.to_be_bytes());
+        sg_cmd.cmdp[4] = 0;
+        sg_cmd.cmdp[5] = 0;
+
+        // Transfer Length
+        let length = u32::from_le(hdr.length);
+        assert!(length > LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE);
+        let transfer_len: u32 = (length as usize - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize)
+            .try_into()
+            .unwrap();
+        sg_cmd.cmdp[6..=9].copy_from_slice(&transfer_len.to_be_bytes());
+        sg_cmd.cmdp[10] = 0;
+        sg_cmd.cmdp[11] = 0;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an IF-RECV/SECURITY_IN command to fetch an SPDM response.
+    /// This should be used when a response is expected from the target device.
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    /// * `message`: response buffer
+    /// * `message_size`: response buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialised command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_libspdm_response(
+        cdb_len: u8,
+        direction: i32,
+        bufsz: u32,
+        message: *mut u8,
+        message_size: usize,
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+        let header_len = LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize;
+        let mut transport_message_len = message_size;
+        // We pass a pointer to this pointer when calling `libspdm_storage_encode_message()`
+        // and buf_ptr ends up being changed to point at a section of `reply` in libspdm.
+        let mut transport_message = ptr::null_mut();
+
+        unsafe {
+            libspdm_storage_encode_message(
+                ptr::null_mut(),
+                0,
+                message_size - header_len,
+                message as *mut _ as *mut c_void,
+                &mut transport_message_len,
+                &mut transport_message as *mut *mut c_void,
+            )
+        };
+
+        let transp_msg = unsafe { from_raw_parts_mut(transport_message, transport_message_len) };
+        let hdr = unsafe { *(transp_msg.as_mut_ptr() as *mut storage_spdm_transport_header) };
+
+        // Setup Security In Command for SPDM response [IF-RECV]
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolIn.into();
+        sg_cmd.cmdp[1] = hdr.security_protocol;
+        // All fields in the storage transport are little endian
+        let spsp = u16::from_le(hdr.security_protocol_specific);
+        sg_cmd.cmdp[2..=3].copy_from_slice(&spsp.to_be_bytes());
+        sg_cmd.cmdp[4] = 0;
+        sg_cmd.cmdp[5] = 0;
+
+        // Allocation Length
+        let length = u32::from_le(hdr.length);
+        assert!(length > LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE);
+        let allocation_len: u32 = (length as usize
+            - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize)
+            .try_into()
+            .unwrap();
+        sg_cmd.cmdp[6..=9].copy_from_slice(&allocation_len.to_be_bytes());
+        sg_cmd.cmdp[10] = 0;
+        sg_cmd.cmdp[11] = 0;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Sets the buffer pointers in SgCmd.io_hdr to point to heap allocated
+    /// io buffers in SgCmd. These buffers must be heap allocated for FFI
+    /// compatibility with C. Behavior maybe undefined otherwise.
+    ///
+    /// # Returns
+    ///
+    /// Ok(()), on success
+    /// Err(()), if io_hdr is None
+    fn set_io_buffer_ptrs(&mut self) {
+        self.io_hdr.cmdp = self.cmdp.as_mut_ptr();
+        self.io_hdr.dxferp = self.dxferp.as_mut_ptr() as *mut c_void;
+        self.io_hdr.sbp = self.sbp.as_mut_ptr();
+    }
+
+    /// # Summary
+    ///
+    /// Execute a command to the device using `ioctl`. The command must be
+    /// setup/generated prior invoking this method.
+    ///
+    /// # Parameter
+    ///
+    /// * `fd: file-descriptor to the device, not that is must be opened
+    ///         with the correct flags for the command.
+    ///
+    /// # Returns
+    ///
+    /// Err(Errno), on failure
+    /// Ok(()), on success
+    fn scsi_cmd_exec(&mut self, fd: i32) -> Result<(), Errno> {
+        let rc = unsafe { ioctl(fd, SG_IO as u64, &mut self.io_hdr as *mut _ as *mut c_void) };
+        if rc != 0 {
+            let rc = Errno::last();
+            error!("SG_IO ioctl failed: {}", rc);
+            return Err(rc);
+        }
+
+        if self.io_hdr.status != 0
+            || self.io_hdr.host_status != SG_DID_OK
+            || ((self.io_hdr.driver_status & SG_DRIVER_STATUS_MASK != 0)
+                && (self.io_hdr.driver_status & SG_DRIVER_STATUS_MASK != SG_DRIVER_SENSE))
+        {
+            if self.io_hdr.host_status == SG_DID_TIME_OUT {
+                error!("SCSI command failed (timeout)");
+                return Err(Errno::ETIMEDOUT);
+            }
+
+            error!("SCSI command failed");
+            return Err(Errno::EIO);
+        }
+
+        if self.io_hdr.resid != 0 {
+            self.bufsz = self.bufsz
+                - u32::try_from(self.io_hdr.resid)
+                    .expect("unexpected overflow converting i32 to u32");
+        }
+        return Ok(());
+    }
+}
+
+/// # Summary
+///
+/// Given a fulfilled sense response from the device, log the Sense Key, ASC
+/// and ASCQ and return the sense_key and asc_ascq concatenated.
+///
+/// # Parameter
+///
+/// * `cmd`: SgCmd in flight
+///
+/// # Returns
+///
+/// Some<(sense_key, asc_ascq)>, if valid
+/// None, if not set
+fn log_and_get_sense(cmd: &SgCmd) -> Option<(u8, u16)> {
+    if ((cmd.sbp[0] & 0x7F) == 0x72) || ((cmd.sbp[0] & 0x7F) == 0x73) {
+        let sense_key = cmd.sbp[1] & 0x0F;
+        let asc_ascq = ((cmd.sbp[2] as u16) << 8) | cmd.sbp[3] as u16;
+        warn!("sense_key: 0x{sense_key:x?}");
+        warn!("asc_ascq: 0x{asc_ascq:x?}");
+        return Some((sense_key, asc_ascq));
+    }
+
+    if ((cmd.sbp[0] & 0x7F) == 0x70) || ((cmd.sbp[0] & 0x7F) == 0x71) {
+        let sense_key = cmd.sbp[2] & 0x0F;
+        let asc_ascq = ((cmd.sbp[12] as u16) << 8) | cmd.sbp[13] as u16;
+        warn!("sense_key: 0x{sense_key:x?}");
+        warn!("asc_ascq: 0x{asc_ascq:x?}");
+        return Some((sense_key, asc_ascq));
+    }
+    debug!("No sense detected");
+    None
+}
+
+/// # Summary
+///
+/// Generate a command to request a list of supported security protocols by the
+/// device. We check for SPDM support.
+///
+/// # Parameter
+///
+/// * `path: path to the device
+///
+/// # Returns
+///
+/// Ok(()), on success
+/// Err(Errno), on any errors
+pub fn cmd_scsi_get_sec_info(path: &String) -> Result<(), Errno> {
+    // 1. Open device
+    let dev = BlkDev::new(path, OFlag::O_RDWR)?;
+    // The actual buffer has a fixed length much larger
+    let bufsz = 256;
+    // 2. Generate command
+    let mut cmd = SgCmd::gen_security_protocols_list(0, SG_DXFER_FROM_DEV, bufsz)?;
+    // 3. Execute CMD
+    if let Some(fd) = &dev.fd {
+        if let Err(e) = cmd.scsi_cmd_exec(*fd) {
+            if let Some((sense_key, asc_ascq)) = log_and_get_sense(&cmd) {
+                if sense_key == 0x06 && asc_ascq == 0x2900 {
+                    // This is a Power ON/Reset/Bus Reset condition, maybe the drive
+                    // wasn't initialized. Retry the command, if it fails again,
+                    // let the caller handle it.
+                    warn!("Sense Condition: Power On/Reset detected");
+                    cmd.scsi_cmd_exec(*fd)?;
+                } else {
+                    return Err(Errno::ENXIO);
+                }
+            } else {
+                return Err(e);
+            }
+        }
+    } else {
+        return Err(Errno::ENXIO);
+    }
+
+    let sec_prot_list_len: u16 = u16::from_be_bytes(
+        cmd.dxferp[6..=7]
+            .try_into()
+            .expect("failed to split slice into constant size array"),
+    );
+
+    info!("--- Security Info List ---");
+    info!("  Length of Security Protocol List: {}", sec_prot_list_len);
+    // As per SFCR: Table 27 — Supported security protocols SECURITY PROTOCOL IN parameter data
+    // Protocol list start at offset 8...N, where N indicates the total length, in bytes,
+    // N = sec_prot_list_len
+    // bufsz - 8 => the remaining bytes in this header
+    assert!((sec_prot_list_len as u32) < bufsz - 8);
+    // If `SUPPORTED SECURITY PROTOCOL` is supported, this length shall be
+    // greater than 0.
+    assert!(sec_prot_list_len > 0);
+
+    if sec_prot_list_len <= 1 {
+        warn!("No security protocols supported by: {:?}", path);
+    }
+    let mut spdm_support = false;
+    for i in 0..sec_prot_list_len {
+        if let Ok(sec_prot) = SpcSecurityProtocols::try_from(cmd.dxferp[(8 + i) as usize] as u8) {
+            info!("  {:?}  - Supported", sec_prot);
+            if sec_prot == SpcSecurityProtocols::DmtfSpdm {
+                spdm_support = true;
+            }
+        }
+    }
+    info!("--- End of Security Information List ---");
+
+    if !spdm_support {
+        // Device does not support SPDM
+        return Err(Errno::ENOTSUP);
+    }
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// Generate a command to get basic device information from the device pointed
+/// to by @path, then print the information returned.
+///
+/// # Parameter
+///
+/// * `path: path to the device
+///
+/// # Returns
+///
+/// Ok(()), on success
+/// Err(Errno), on any errors
+pub fn cmd_scsi_get_info(path: &String) -> Result<(), Errno> {
+    // 1. Open device
+    let dev = BlkDev::new(path, OFlag::O_RDONLY)?;
+    // 2. Generate command
+    let mut cmd = SgCmd::gen_dev_inquiry_info(0, SG_DXFER_FROM_DEV, 64)?;
+    // 3. Execute CMD
+    if let Some(fd) = &dev.fd {
+        cmd.scsi_cmd_exec(*fd).map_err(|e| {
+            error!("Failure to issue get info command: {e:?}");
+            e
+        })?;
+    } else {
+        return Err(Errno::ENXIO);
+    }
+
+    // 4. Display results
+    let vendor = String::from_utf8(cmd.dxferp[8..8 + (DEV_VENDOR_LEN - 1)].to_vec()).unwrap();
+    let id = String::from_utf8(cmd.dxferp[16..16 + (DEV_ID_LEN - 1)].to_vec()).unwrap();
+    let rev = String::from_utf8(cmd.dxferp[8..32 + (DEV_REV_LEN - 1)].to_vec()).unwrap();
+
+    info!("vendor: {vendor}");
+    info!("id: {id}");
+    info!("rev: {rev}");
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn scsi_send_message(
+    _context: *mut c_void,
+    message_size: usize,
+    message_ptr: *const c_void,
+    _timeout: u64,
+) -> u32 {
+    info!("Sending SCSI SECURITY_OUT SPDM Command (request)");
+
+    match &mut *SCSI_DEV.lock().unwrap() {
+        // 1. Get device
+        Some(dev) => {
+            let message = message_ptr as *const u8;
+            let msg_buf = unsafe { from_raw_parts(message, message_size) };
+            // 2. Generate Request Header
+            let header_len = LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize;
+            let mut cmd = SgCmd::gen_libspdm_request(
+                0,
+                SG_DXFER_TO_DEV,
+                SG_BUF_MAX_SIZE,
+                &mut msg_buf[0..header_len].try_into().unwrap(),
+            )
+            .unwrap();
+
+            assert!(message_size < cmd.dxferp.capacity());
+            // Copy in SPDM buffer to the SG command IO buffer
+            for i in 0..message_size - header_len {
+                cmd.dxferp[i] = msg_buf[i + header_len];
+            }
+
+            // 3. Execute CMD
+            debug!(
+                "spdm-sending: IF_SEND: cmdp:   {:x?}",
+                &cmd.cmdp[0..SCSI_SEC_IN_OUT_CDB_LEN]
+            );
+            debug!(
+                "spdm-sending: dxferp: {:x?}",
+                &cmd.dxferp[0..(message_size - header_len)]
+            );
+
+            if let Some(fd) = &dev.fd {
+                cmd.scsi_cmd_exec(*fd)
+                    .expect("Failed to execute cmd, security in failed");
+            }
+        }
+        None => unreachable!("SCSI device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `SEND_RECEIVE_BUFFER_LEN` to capture the received bytes.
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[no_mangle]
+unsafe extern "C" fn scsi_receive_message(
+    _context: *mut c_void,
+    message_size: *mut usize,
+    message_ptr: *mut *mut c_void,
+    _timeout: u64,
+) -> u32 {
+    match &mut *SCSI_DEV.lock().unwrap() {
+        // 1. Get device
+        Some(dev) => {
+            let message = *message_ptr as *mut u8;
+            let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+
+            info!("Sending SCSI SECURITY_IN SPDM Command (receive response)");
+            // 2. Generate Response Header
+            let mut cmd = SgCmd::gen_libspdm_response(
+                0,
+                SG_DXFER_FROM_DEV,
+                SG_BUF_MAX_SIZE,
+                message,
+                *message_size,
+            )
+            .unwrap();
+
+            // 3. Execute CMD
+            debug!(
+                "spdm-sending: IF_RECV: cmdp:   {:x?}",
+                &cmd.cmdp[0..SCSI_SEC_IN_OUT_CDB_LEN]
+            );
+
+            if let Some(fd) = &dev.fd {
+                cmd.scsi_cmd_exec(*fd)
+                    .expect("Failed to execute cmd, security in failed");
+            }
+
+            // 4. Copy in the received buffer
+            assert!(cmd.bufsz > 0);
+            assert!(msg_buf.len() >= cmd.bufsz as usize);
+            assert!(cmd.dxferp.len() >= cmd.bufsz as usize);
+
+            for i in 0..cmd.bufsz as usize {
+                msg_buf[i] = cmd.dxferp[i];
+            }
+
+            // Allow libspdm to do top-bottom SPDM message parsing, we don't know the
+            // number of valid bytes in the reception buffer.
+            *message_size = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
+
+            info!("recvd_bytes: {:?}", *message_size);
+            info!("spdm-recvd: {:x?}", &msg_buf[0..*message_size]);
+        }
+        None => unreachable!("SCSI device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+///
+/// # Parameter
+///
+/// * `context`: The SPDM context
+///
+/// # Returns
+///
+/// Ok(()) on success
+///
+/// # Panics
+///
+/// Panics if `SEND_BUFFER/RECEIVE_BUFFER` is occupied
+pub fn register_device(context: *mut c_void, dev_path: &String) -> Result<(), ()> {
+    unsafe {
+        *SCSI_DEV.lock().unwrap() = Some(BlkDev::new(dev_path, OFlag::O_RDWR).unwrap());
+        libspdm_register_device_io_func(
+            context,
+            Some(scsi_send_message),
+            Some(scsi_receive_message),
+        );
+        io_buffers::libspdm_setup_io_buffers(
+            context,
+            SEND_RECEIVE_BUFFER_LEN,
+            SEND_RECEIVE_BUFFER_LEN,
+        )?;
+    }
+
+    Ok(())
+}

--- a/src/storage_standards.rs
+++ b/src/storage_standards.rs
@@ -5,7 +5,6 @@
 //! Contains all of the handlers for creating SPDM requests.
 
 /// SCSI SPDM Related ADDITIONAL SENSE CODE (ASQ)
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ScsiAsc {
     InvalidFieldInCdb = 0x24, // ASCQ = 0x00
@@ -13,7 +12,6 @@ pub enum ScsiAsc {
 
 /// Defines the SPDM return status (upper byte) and error (lower byte)
 /// for ATA as defined in DSP0284.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum AtaStatusErr {
     Success = 0x5000,
@@ -21,7 +19,6 @@ pub enum AtaStatusErr {
 }
 
 /// NVME Completion Queue Command Completion Status
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum NvmeCmdStatus {
     NvmeSuccess = 0x0000,

--- a/src/storage_standards.rs
+++ b/src/storage_standards.rs
@@ -1,0 +1,92 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2024, Western Digital Corporation or its affiliates.
+
+//! Contains all of the handlers for creating SPDM requests.
+
+/// SCSI SPDM Related ADDITIONAL SENSE CODE (ASQ)
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum ScsiAsc {
+    InvalidFieldInCdb = 0x24, // ASCQ = 0x00
+}
+
+/// Defines the SPDM return status (upper byte) and error (lower byte)
+/// for ATA as defined in DSP0284.
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum AtaStatusErr {
+    Success = 0x5000,
+    InvalidCommand = 0x5104,
+}
+
+/// NVME Completion Queue Command Completion Status
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum NvmeCmdStatus {
+    NvmeSuccess = 0x0000,
+    NvmeInvalidFieldInCmd = 0x0002,
+    NvmeDoNotRetry = 0x4000,
+}
+
+/// Spdm Storage Operations as defined in DMTF DSP0286
+#[derive(Debug, PartialEq)]
+pub enum SpdmOperationCodes {
+    SpdmStorageDiscovery = 0x01,
+    SpdmStoragePendingInfo = 0x02,
+    SpdmStorageMessage = 0x05,
+    SpdmStorageSecMessage = 0x06,
+}
+
+impl TryFrom<u8> for SpdmOperationCodes {
+    type Error = ();
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            0x01 => Ok(SpdmOperationCodes::SpdmStorageDiscovery),
+            0x02 => Ok(SpdmOperationCodes::SpdmStoragePendingInfo),
+            0x05 => Ok(SpdmOperationCodes::SpdmStorageMessage),
+            0x06 => Ok(SpdmOperationCodes::SpdmStorageSecMessage),
+            _ => Err(()),
+        }
+    }
+}
+
+impl From<SpdmOperationCodes> for u8 {
+    fn from(op: SpdmOperationCodes) -> Self {
+        match op {
+            SpdmOperationCodes::SpdmStorageDiscovery => 0x01,
+            SpdmOperationCodes::SpdmStoragePendingInfo => 0x02,
+            SpdmOperationCodes::SpdmStorageMessage => 0x05,
+            SpdmOperationCodes::SpdmStorageSecMessage => 0x06,
+        }
+    }
+}
+
+/// Relevant Security Protocols as specified in Working Draft SCSI Primary
+/// Commands - 6 (SPC-6)
+#[derive(Debug, PartialEq)]
+pub enum SpcSecurityProtocols {
+    SecurityProtocolInformation,
+    DmtfSpdm,
+}
+
+impl From<SpcSecurityProtocols> for u8 {
+    fn from(c: SpcSecurityProtocols) -> Self {
+        match c {
+            SpcSecurityProtocols::SecurityProtocolInformation => 0x00,
+            SpcSecurityProtocols::DmtfSpdm => 0xE8,
+        }
+    }
+}
+
+impl TryFrom<u8> for SpcSecurityProtocols {
+    type Error = ();
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0x00 => Ok(SpcSecurityProtocols::SecurityProtocolInformation),
+            0xE8 => Ok(SpcSecurityProtocols::DmtfSpdm),
+            _ => Err(()),
+        }
+    }
+}
+

--- a/src/storage_standards.rs
+++ b/src/storage_standards.rs
@@ -89,4 +89,3 @@ impl TryFrom<u8> for SpcSecurityProtocols {
         }
     }
 }
-

--- a/wrapper.h
+++ b/wrapper.h
@@ -4,6 +4,8 @@
 
 #ifdef RUST_STD
 #include <pci/pci.h>
+#include <scsi/scsi.h>
+#include <scsi/sg.h>
 #endif
 
 #include <library/spdm_common_lib.h>
@@ -15,6 +17,7 @@
 #include <library/spdm_secured_message_lib.h>
 #include <library/spdm_transport_pcidoe_lib.h>
 #include <library/spdm_transport_mctp_lib.h>
+#include <library/spdm_transport_storage_lib.h>
 #ifdef LIBSPDM_TESTS
 #include <library/spdm_responder_conformance_test_lib.h>
 #endif
@@ -23,3 +26,4 @@
 #include <internal/libspdm_common_lib.h>
 #include <internal/libspdm_requester_lib.h>
 #include <industry_standard/pcidoe.h>
+#include <industry_standard/spdm_storage_binding.h>

--- a/wrapper.h
+++ b/wrapper.h
@@ -6,6 +6,7 @@
 #include <pci/pci.h>
 #include <scsi/scsi.h>
 #include <scsi/sg.h>
+#include <libnvme.h>
 #endif
 
 #include <library/spdm_common_lib.h>


### PR DESCRIPTION
As per DMTF DSP0286 (pending ratification), this series adds supports to `spdm-utils` to communicate `spdm` with `scsi` and `nvme` devices over the respective security commands. This series also adds  support for a `qemu-server`. Which can to be connected to by `qemu`, and implement an SPDM responder for SCSI/ATA & NVMe devices. 