### PR TITLE
Prepare for Rust 2024 edition

### DIFF
--- a/src/io_buffers.rs
+++ b/src/io_buffers.rs
@@ -61,7 +61,7 @@ pub unsafe extern "C" fn acquire_sender_buffer(
 ) -> u32 {
     if let Some(ref buf) = *SEND_BUFFER.lock().unwrap() {
         let buf_ptr = buf.as_ptr() as *mut c_void;
-        *msg_buf_ptr = buf_ptr;
+        unsafe { *msg_buf_ptr = buf_ptr };
         return 0;
     }
 
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn acquire_receiver_buffer(
 ) -> u32 {
     if let Some(ref buf) = *RECEIVE_BUFFER.lock().unwrap() {
         let buf_ptr = buf.as_ptr() as *mut c_void;
-        *msg_buf_ptr = buf_ptr;
+        unsafe { *msg_buf_ptr = buf_ptr };
         return 0;
     }
     error!("Receiver buffer is lost or not initialized");

--- a/src/main.rs
+++ b/src/main.rs
@@ -898,13 +898,9 @@ async fn main() -> Result<(), ()> {
         }
         Commands::Tests {} => {
             if cli.doe_pci_cfg {
-                unsafe {
-                    test_suite::start_tests(cntx_ptr, test_suite::TestBackend::DoeBackend);
-                }
+                test_suite::start_tests(cntx_ptr, test_suite::TestBackend::DoeBackend);
             } else if cli.socket_server || cli.socket_client {
-                unsafe {
-                    test_suite::start_tests(cntx_ptr, test_suite::TestBackend::SocketBackend);
-                }
+                test_suite::start_tests(cntx_ptr, test_suite::TestBackend::SocketBackend);
             } else {
                 error!("The backend is not supported for testing");
                 return Err(());
@@ -939,7 +935,7 @@ async fn generate_kernel_hash() -> Result<(), std::io::Error> {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "RwLock error",
-            ))
+            ));
         }
     };
 
@@ -1006,7 +1002,7 @@ async fn generate_app_hash() -> Result<(), std::io::Error> {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
                 "RwLock error",
-            ))
+            ));
         }
     };
 

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -138,8 +138,8 @@ unsafe extern "C" fn qemu_receive_message_doe(
 ) -> u32 {
     match &mut *CLIENT_CONNECTION.lock().unwrap() {
         Some(stream) => {
-            let message = *msg_buf_ptr as *mut u8;
-            let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+            let message = unsafe { *msg_buf_ptr as *mut u8 };
+            let msg_buf = unsafe { from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN) };
 
             if timeout == 0 {
                 stream
@@ -178,7 +178,7 @@ unsafe extern "C" fn qemu_receive_message_doe(
                 std::process::exit(0);
             }
 
-            *message_size = read_len;
+            unsafe { *message_size = read_len };
         }
         None => {
             unreachable!("Client connection lost")
@@ -293,8 +293,8 @@ unsafe extern "C" fn qemu_receive_message_mctp(
 ) -> u32 {
     match &mut *CLIENT_CONNECTION.lock().unwrap() {
         Some(stream) => {
-            let message = *msg_buf_ptr as *mut u8;
-            let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+            let message = unsafe { *msg_buf_ptr as *mut u8 };
+            let msg_buf = unsafe { from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN) };
 
             if timeout == 0 {
                 stream
@@ -333,7 +333,7 @@ unsafe extern "C" fn qemu_receive_message_mctp(
                 std::process::exit(0);
             }
 
-            *message_size = read_len;
+            unsafe { *message_size = read_len };
         }
         None => {
             unreachable!("Client connection lost")

--- a/src/request.rs
+++ b/src/request.rs
@@ -415,7 +415,10 @@ pub fn prepare_request(
                         ptr::null_mut(),
                     );
                     if LibspdmReturnStatus::libspdm_status_is_error(ret) {
-                        println!("Failed to authenticate endpoint through the challenge-response protocol. libspdm error: 0x{:x}", ret);
+                        println!(
+                            "Failed to authenticate endpoint through the challenge-response protocol. libspdm error: 0x{:x}",
+                            ret
+                        );
                         return Err(ret);
                     }
                 } else {
@@ -561,9 +564,13 @@ pub fn prepare_request(
                         // Don't need to error here since it's the responder
                         // that does not support this feature.
                         if secure_msg {
-                            error!("Responder does not support Encapsulated Request capability with secure messages");
+                            error!(
+                                "Responder does not support Encapsulated Request capability with secure messages"
+                            );
                         } else {
-                            error!("Responder does not support Encapsulated Request capability with non-secure messages");
+                            error!(
+                                "Responder does not support Encapsulated Request capability with non-secure messages"
+                            );
                         }
                     } else {
                         return Err(ret);
@@ -699,198 +706,201 @@ pub fn prepare_request(
 /// # Panics
 ///
 /// Panics on invalid `cntx_ptr`
-pub unsafe fn get_responder_capabilities(cntx_ptr: *mut c_void) {
+pub fn get_responder_capabilities(cntx_ptr: *mut c_void) {
     info!("The responder supports the following capabilities:");
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_CERT_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_CERT_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP");
-    }
-    if libspdm_is_capabilities_flag_supported(
-        cntx_ptr as *const libspdm_context_t,
-        true,
-        0,
-        SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_INSTALL_RESET_CAP,
-    ) {
-        info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_INSTALL_RESET_CAP");
+
+    unsafe {
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CACHE_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHAL_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_NO_SIG");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_CAP_SIG");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MEAS_FRESH_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCRYPT_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MAC_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_MUT_AUTH_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_EX_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PSK_CAP_RESPONDER_WITH_CONTEXT");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ENCAP_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HBEAT_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_KEY_UPD_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_HANDSHAKE_IN_THE_CLEAR_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_PUB_KEY_ID_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CHUNK_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_ALIAS_CERT_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_CERT_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_SET_CERT_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CSR_CAP");
+        }
+        if libspdm_is_capabilities_flag_supported(
+            cntx_ptr as *const libspdm_context_t,
+            true,
+            0,
+            SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_INSTALL_RESET_CAP,
+        ) {
+            info!(" -SPDM_GET_CAPABILITIES_RESPONSE_FLAGS_CERT_INSTALL_RESET_CAP");
+        }
     }
 }

--- a/src/socket_client.rs
+++ b/src/socket_client.rs
@@ -106,8 +106,8 @@ unsafe extern "C" fn sclient_receive_message(
 ) -> u32 {
     match &mut *CLIENT_CONNECTION.lock().unwrap() {
         Some(stream) => {
-            let message = *msg_buf_ptr as *mut u8;
-            let msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+            let message = unsafe { *msg_buf_ptr as *mut u8 };
+            let msg_buf = unsafe { from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN) };
 
             if timeout == 0 {
                 stream
@@ -134,7 +134,7 @@ unsafe extern "C" fn sclient_receive_message(
                 std::process::exit(0);
             }
 
-            *message_size = read_len;
+            unsafe { *message_size = read_len };
         }
         None => {
             unreachable!("Socket stream lost")

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -70,7 +70,7 @@ pub fn setup_test_backend(cntx: *mut c_void) -> Result<SpdmSessionInfo, u32> {
     }
 
     info!("[{slot_id}] Listing Responder Capabilities");
-    unsafe { request::get_responder_capabilities(cntx) };
+    request::get_responder_capabilities(cntx);
 
     Ok(session_info)
 }
@@ -497,7 +497,7 @@ pub fn test_set_certificate(cntx: *mut c_void, cert_slot_id: u8) -> Result<(), (
 /// # Returns
 ///
 /// Does not return, the process will exit after tests are complete.
-pub unsafe fn start_tests(cntx: *mut c_void, backend: TestBackend) -> ! {
+pub fn start_tests(cntx: *mut c_void, backend: TestBackend) -> ! {
     match backend {
         TestBackend::DoeBackend => {
             // Run DOE conformance tests
@@ -558,7 +558,7 @@ pub unsafe fn start_tests(cntx: *mut c_void, backend: TestBackend) -> ! {
 /// failure. If during tests, the tests hang (do not complete), the `test.log`
 /// should be looked at to find the point of failure.
 #[allow(unused_variables)]
-pub unsafe fn responder_validator_tests(context: *mut c_void) -> Result<(), ()> {
+pub fn responder_validator_tests(context: *mut c_void) -> Result<(), ()> {
     #[cfg(feature = "libspdm_tests")]
     {
         let mut m_spdm_test_group_capabilities_configs = [
@@ -1035,7 +1035,9 @@ pub unsafe fn responder_validator_tests(context: *mut c_void) -> Result<(), ()> 
             &m_spdm_responder_validator_config as *const common_test_suite_config_t,
         );
 
-        info!("\n---- Responder-Validator Tests Complete. See `log` to check the results of libspdm tests ----\n");
+        info!(
+            "\n---- Responder-Validator Tests Complete. See `log` to check the results of libspdm tests ----\n"
+        );
     }
 
     Ok(())

--- a/src/usb_i2c.rs
+++ b/src/usb_i2c.rs
@@ -186,8 +186,8 @@ unsafe extern "C" fn usb_i2c_receive_message(
 ) -> u32 {
     match &mut *MCTPCONTEXT.lock().unwrap() {
         Some(mctp_ctx) => {
-            let message = *message_ptr as *mut u8;
-            let spdm_msg_buf = from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN);
+            let message = unsafe { *message_ptr as *mut u8 };
+            let spdm_msg_buf = unsafe { from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN) };
             spdm_msg_buf.fill(0);
 
             info!("Receiving message");
@@ -234,7 +234,7 @@ unsafe extern "C" fn usb_i2c_receive_message(
 
             debug!("mctp_buf: {:x?}", &spdm_msg_buf[0..len]);
 
-            *message_size = len;
+            unsafe { *message_size = len };
 
             *SERIAL_PORT.lock().unwrap() = Some(port);
         }


### PR DESCRIPTION
This preapres for the update to the Rust 2024 edition.

After this PR is merged we can at least build (with warnings) Rust 2024.
Rust 2024 needs Rust 1.85, which we don't really want just yet, but let's
at least get ready.

This is a fairly mechanical change, mostly just wrapping unsafe function
calls with unsafe instead of relying on the calling function being
unsafe.

This brings the number of unsafe keywords in our code base significantly
higher, which is a shame. Overall the actual unsafe code is the same,
just more accurately described.

Hopefully this can be improved in the future, especially if we can remove
some of the C style pointer operations.