### PR TITLE
Check DOE availability on the matching devices

### DIFF
--- a/src/doe_pci_cfg.rs
+++ b/src/doe_pci_cfg.rs
@@ -365,7 +365,9 @@ pub fn get_pcie_dev(dev_vid: u16, dev_id: u16) -> Result<(*mut pci_access, *mut 
 
         if unsafe { (*device).vendor_id == dev_vid && (*device).device_id == dev_id } {
             // Device found
-            break;
+            if let Ok(_doe_offset) = get_doe_offset(device) {
+                break;
+            }
         }
         unsafe { device = (*device).next };
     }


### PR DESCRIPTION
When using '--doe-pci-cfg --pcie-vid vid-hex --pcie-devid did-hex' to
identify a PCIe EP and use its DOE as transport, if the first enumerated
device with a matching vendor ID and device ID lacks CMA/DOE support,
the code will error out, even if other matching devices do have CMA/DOE
support.

Check DOE availability on the matching device; if unavailable, proceed
to the next matching device in get_pcie_dev().