### PR TITLE
responder: allow for multiple supported spdm versions

### DIFF
--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -70,27 +70,6 @@ pub fn parse_pcie_identifiers(vid: String, dev_id: String) -> Result<(u16, u16),
 
 /// # Summary
 ///
-/// Parses the CLI argument for the SPDM version used by a responder.
-///
-/// # Parameter
-///
-/// * `spdm_ver`: String option containing the version (1.0, 1,1 ...etc)
-///
-/// # Returns
-///
-/// The corresponding libspdm value for the version, None if not found.
-pub fn parse_spdm_responder_version(spdm_ver: Option<String>) -> Option<u8> {
-    spdm_ver.and_then(|ver| match ver.as_str() {
-        "1.0" => u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_10).ok(),
-        "1.1" => u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_11).ok(),
-        "1.2" => u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_12).ok(),
-        "1.3" => u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_13).ok(),
-        _ => None,
-    })
-}
-
-/// # Summary
-///
 /// Parses the CLI based AEAD Cipher Suites
 ///
 /// # Parameter

--- a/tock-responder/src/main.rs
+++ b/tock-responder/src/main.rs
@@ -9,6 +9,8 @@
 
 extern crate alloc;
 
+use alloc::vec;
+use alloc::vec::Vec;
 use core::fmt::Write;
 use critical_section::RawRestoreState;
 use embedded_alloc::Heap;
@@ -75,10 +77,11 @@ fn main() {
     )
     .unwrap();
 
+    let spdm_ver: Vec<u16> = vec![libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_13 as u16];
     responder::setup_capabilities(
         cntx_ptr,
         0,
-        Some(u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_13).unwrap()),
+        Some(&spdm_ver),
         SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
         SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384,
         CertModel::Alias,
@@ -92,11 +95,7 @@ fn main() {
         "spdm-sample: starting response_loop...\r",
     )
     .unwrap();
-    responder::set_supported_slots_mask(
-        1,
-        Some(u8::try_from(libspdm::libspdm_rs::SPDM_MESSAGE_VERSION_13).unwrap()),
-        cntx_ptr,
-    )
-    .expect("failed to set supported slot mask");
+    responder::set_supported_slots_mask(1, &spdm_ver, cntx_ptr)
+        .expect("failed to set supported slot mask");
     responder::response_loop(cntx_ptr);
 }


### PR DESCRIPTION
Currently, the responder is only allowed to specify a single SPDM
version. Instead, allow a user to specify multiple spdm versions which a
requestor can negotiate and use. For the responder, multiple supported
versions can be specified as "response --spdm-ver=1.0,1.2,1.3".

This is what the requestor sees now when the responder supports 1.0, 1.2 and 1.3
```
./target/debug/spdm_utils --socket-client --no-session request get-version
[2025-12-31T06:15:04Z DEBUG spdm_utils] Logger initialisation [OK]
[2025-12-31T06:15:04Z INFO  spdm_utils::socket_client] Connected to server
[2025-12-31T06:15:04Z DEBUG spdm_utils::cli_helpers] Specified Algos: 128
[2025-12-31T06:15:04Z DEBUG spdm_utils::cli_helpers] Specified hashing Algos: 2
[2025-12-31T06:15:04Z DEBUG spdm_utils::cli_helpers] Specified dhe groups: 48
[2025-12-31T06:15:04Z DEBUG spdm_utils::cli_helpers] Specified aead cipher suites: 2
libspdm_send_spdm_request[0] msg SPDM_GET_VERSION(0x84), size (0x4): 
0000: 10 84 00 00 
libspdm_receive_spdm_response[0] msg SPDM_VERSION(0x4), size (0xc): 
0000: 10 04 00 00 00 03 00 10 00 12 00 13 
[2025-12-31T06:15:04Z INFO  spdm_utils::request] Responder SpdmVersion: 1.3.0.0
```