### PR TITLE
build: add nix flake to build with nix package manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See LICENSE-APACHE, LICENSE-MIT, and COPYRIGHT for details.
 
 - [Dependencies](#dependencies)
     - [Fedora](#fedora)
+- [Building with Nix](#building-with-nix)
 - [Building](#building)
     - [Build libspdm](#build-libspdm)
     - [Build the binary](#build-the-binary)
@@ -103,6 +104,53 @@ home/<user>/bin/cbor2diag.rb
 When building `spdm-utils` it will generate a `manifest.out.cbor` which contains
 the serialised cbor manifest, and also a `manifest.pretty` which is the *pretty* format
 of the manifest (user friendly).
+
+# Building with Nix
+
+If you have [Nix](https://nixos.org/) installed with flakes enabled, you can build
+SPDM-Utils without manually installing any dependencies.
+
+## Quick Build
+
+To build the release binary directly:
+
+```shell
+$ nix build .#
+```
+
+The resulting binary will be available at `./result/bin/spdm_utils`.
+
+## Development Shell
+
+For development, you can enter a shell with all dependencies available:
+
+```shell
+$ nix develop
+```
+
+Then build libspdm (only needed once, or after submodule updates):
+
+```shell
+$ cd third-party/libspdm
+$ mkdir -p build && cd build
+$ cmake -DARCH=x64 -DTOOLCHAIN=GCC -DTARGET=Debug -DCRYPTO=openssl \
+    -DENABLE_BINARY_BUILD=1 -DCOMPILED_LIBCRYPTO_PATH=/usr/lib/ \
+    -DCOMPILED_LIBSSL_PATH=/usr/lib/ -DDISABLE_TESTS=1 \
+    -DCMAKE_C_FLAGS="-DLIBSPDM_ENABLE_CAPABILITY_EVENT_CAP=0 \
+    -DLIBSPDM_ENABLE_CAPABILITY_MEL_CAP=0 \
+    -DLIBSPDM_HAL_PASS_SPDM_CONTEXT=1 \
+    -DLIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP=0 \
+    -DLIBSPDM_ENABLE_CAPABILITY_SET_KEY_PAIR_INFO_CAP=0 \
+    -DLIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP=0" ..
+$ make -j$(nproc)
+$ cd ../../..
+```
+
+Then build spdm-utils:
+
+```shell
+$ cargo build
+```
 
 # Building
 

--- a/certs/setup_certs.sh
+++ b/certs/setup_certs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 ### This script updates and signs the mutable SPDM-Utils certificates ###

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,112 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "libspdm-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756881433,
+        "narHash": "sha256-YIOPY+32G3MvJ7G3S/85Q9fbCjneKIEXIffdJEcRTyA=",
+        "rev": "d7c8c8247b4d0bd8ed75d9f35a558a4df173a4c7",
+        "revCount": 2292,
+        "type": "git",
+        "url": "file:third-party/libspdm"
+      },
+      "original": {
+        "type": "git",
+        "url": "file:third-party/libspdm"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770136044,
+        "narHash": "sha256-tlFqNG/uzz2++aAmn4v8J0vAkV3z7XngeIIB3rM3650=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e576e3c9cf9bad747afcddd9e34f51d18c855b4e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1744536153,
+        "narHash": "sha256-awS2zRgF4uTwrOKwwiJcByDzDOdo3Q1rPZbiHQg/N38=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "18dd725c29603f582cf1900e0d25f9f1063dbf11",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "libspdm-src": "libspdm-src",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1770174315,
+        "narHash": "sha256-GUaMxDmJB1UULsIYpHtfblskVC6zymAaQ/Zqfo+13jc=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "095c394bb91342882f27f6c73f64064fb9de9f2a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,136 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = { url = "github:oxalica/rust-overlay"; };
+    libspdm-src = {
+      url = "git+file:third-party/libspdm";
+      flake = false;
+    };
+  };
+
+  outputs = inputs:
+    with inputs;
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ (import inputs.rust-overlay) ];
+        pkgs = import inputs.nixpkgs { inherit overlays system; };
+
+        libspdm-src = inputs.libspdm-src;
+
+        libspdm = pkgs.stdenv.mkDerivation {
+          pname = "libspdm";
+          version = "3.0.0";
+
+          src = libspdm-src;
+
+          nativeBuildInputs = [ pkgs.cmake ];
+          buildInputs = [ pkgs.openssl ];
+
+          hardeningDisable = [ "all" ];
+          NIX_CFLAGS_COMPILE = "-fno-lto";
+
+          CFLAGS =
+            "-DLIBSPDM_ENABLE_CAPABILITY_EVENT_CAP=0 -DLIBSPDM_ENABLE_CAPABILITY_MEL_CAP=0 -DLIBSPDM_HAL_PASS_SPDM_CONTEXT=1 -DLIBSPDM_ENABLE_CAPABILITY_GET_KEY_PAIR_INFO_CAP=0 -DLIBSPDM_ENABLE_CAPABILITY_SET_KEY_PAIR_INFO_CAP=0 -DLIBSPDM_ENABLE_CAPABILITY_ENDPOINT_INFO_CAP=0";
+
+          cmakeFlags = [
+            "-DARCH=x64"
+            "-DTOOLCHAIN=GCC"
+            "-DTARGET=Release"
+            "-DCRYPTO=openssl"
+            "-DENABLE_BINARY_BUILD=1"
+            "-DCOMPILED_LIBCRYPTO_PATH=${pkgs.openssl.out}/lib"
+            "-DCOMPILED_LIBSSL_PATH=${pkgs.openssl.out}/lib"
+            "-DDISABLE_TESTS=1"
+          ];
+
+          installPhase = ''
+            mkdir -p $out/lib $out/include
+            cp -r lib/*.a $out/lib/
+            cp -r ../include/* $out/include/
+          '';
+        };
+
+        spdm-utils = pkgs.rustPlatform.buildRustPackage {
+          pname = "spdm-utils";
+          version = "1.0.0";
+
+          src = pkgs.lib.cleanSourceWith {
+            src = ./.;
+            filter = path: type:
+              let
+                baseName = baseNameOf path;
+                relPath = pkgs.lib.removePrefix (toString ./. + "/") path;
+                # Include Rust source files
+              in (pkgs.lib.hasSuffix ".rs" baseName)
+              || (pkgs.lib.hasSuffix ".toml" baseName)
+              || (baseName == "Cargo.lock") || (baseName == "build.rs")
+              || (baseName == "wrapper.h") ||
+              # Include certs directory
+              (pkgs.lib.hasPrefix "certs" relPath) ||
+              # Include manifest directory
+              (pkgs.lib.hasPrefix "manifest" relPath) ||
+              # Exclude third-party (we get libspdm from input)
+              !(pkgs.lib.hasPrefix "third-party" relPath) &&
+              # Allow directories to be traversed
+              (type == "directory");
+          };
+
+          cargoLock = { lockFile = ./Cargo.lock; };
+
+          nativeBuildInputs = [ pkgs.pkg-config pkgs.libclang pkgs.openssl ];
+
+          buildInputs = [ pkgs.udev pkgs.pciutils pkgs.openssl libspdm ];
+
+          hardeningDisable = [ "all" ];
+
+          preBuild = ''
+            # Create the expected libspdm directory structure
+            mkdir -p third-party/libspdm/build/lib
+            mkdir -p third-party/libspdm/include
+            ln -sf ${libspdm}/lib/*.a third-party/libspdm/build/lib/
+            cp -r ${libspdm-src}/include/* third-party/libspdm/include/
+            cp -r ${libspdm-src}/os_stub third-party/libspdm/
+
+            # Generate certificates if they don't exist
+            if [ ! -f certs/alias/slot0/bundle_responder.certchain.der ]; then
+              pushd certs
+              bash ./setup_certs.sh || true
+              popd
+            fi
+          '';
+
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS =
+            "-I${pkgs.pciutils}/include -I${pkgs.glibc.dev}/include -I${libspdm-src}/include";
+          NIX_CFLAGS_COMPILE = "-fno-lto";
+          NIX_CFLAGS_LINK = "-fno-lto";
+        };
+
+      in {
+        packages.default = spdm-utils;
+        packages.libspdm = libspdm;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            pkgs.rust-bin.stable.latest.complete
+            pkgs.pkg-config
+            pkgs.udev
+            pkgs.libclang
+            pkgs.pciutils
+            pkgs.bash
+            pkgs.coreutils
+            pkgs.openssl
+            pkgs.cmake
+            pkgs.gnumake
+            pkgs.gcc
+          ];
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+          BINDGEN_EXTRA_CLANG_ARGS =
+            "-I${pkgs.pciutils}/include -I${pkgs.glibc.dev}/include";
+          hardeningDisable = [ "all" ];
+          NIX_CFLAGS_COMPILE = "-fno-lto";
+          NIX_CFLAGS_LINK = "-fno-lto";
+        };
+      });
+}


### PR DESCRIPTION
Add a nix flake to enable builds with the nix package manager. Also update readme with instructions.

Change shebang in `cert/setup_certs.sh`, because we don't all keep bash in the same place.