### PR TITLE
bindgen: suppress transmute build warnings

### DIFF
--- a/src/libspdm/libspdm_rs.rs
+++ b/src/libspdm/libspdm_rs.rs
@@ -11,4 +11,5 @@
 #![allow(non_upper_case_globals)]
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
+#![allow(unnecessary_transmutes)]
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));


### PR DESCRIPTION
Currently, bindgen generates the following warnings when building. Newer rustc expects a safe cast, but bindgen uses transmute(), this should still be safe but we get warnings. So suppress them for now.

warning: unnecessary transmute
     --> <blah>/build/SPDM-Utils-69b545efe42d6c05/out/bindings.rs:16396:41
      |
16396 |             let _flags2: u32 = unsafe { ::core::mem::transmute(_flags2) };
      |                                         ----------------------^^^^^^^^^
      |                                         |
      |					help: replace this with: i32::cast_unsigned

Resolves: https://github.com/westerndigitalcorporation/spdm-utils/issues/169