### PR TITLE
qemu-server: add storage support to the responder

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ $ ./target/debug/spdm_utils --qemu-server response
 
 Note: You can provide `--qemu-port <QEMU_PORT>` to specify a port for the server
 and also `--spdm-transport-protocol <TRANSPORT>` to specify the transport layer.
+The qemu response server supports `doe` and `storage` transport protocols.
 
 This will start SPDM-Utils responder server on port 2323 (default). QEMU can now be
 started. Once QEMU starts, if the connection is successful, the following logs

--- a/src/qemu_server.rs
+++ b/src/qemu_server.rs
@@ -17,15 +17,66 @@ use std::net::{TcpListener, TcpStream};
 use std::slice::{from_raw_parts, from_raw_parts_mut};
 use std::sync::Mutex;
 use std::time::Duration;
+use storage_standards::{AtaStatusErr, NvmeCmdStatus, ScsiAsc, SpdmStorageOperationCodes};
 
 const SEND_RECEIVE_BUFFER_LEN: usize = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
+const TRANSPORT_MSG_BUF_SIZE: usize = 32;
 
 const SOCKET_SPDM_COMMAND_NORMAL: u32 = 0x01;
+const SOCKET_SPDM_STORAGE_IF_SEND: u32 = 0x02;
+const SOCKET_SPDM_STORAGE_IF_RECV: u32 = 0x03;
+const SOCKET_SPDM_STORAGE_ACK_STATUS: u32 = 0x04;
 
 const SOCKET_TRANSPORT_TYPE_MCTP: u32 = 0x01;
 const SOCKET_TRANSPORT_TYPE_PCI_DOE: u32 = 0x02;
 
 static CLIENT_CONNECTION: Lazy<Mutex<Option<TcpStream>>> = Lazy::new(|| Mutex::new(None));
+const SOCKET_TRANSPORT_TYPE_SCSI: u32 = 0x03;
+const SOCKET_TRANSPORT_TYPE_NVME: u32 = 0x04;
+const SOCKET_TRANSPORT_TYPE_ATA: u32 = 0x05;
+
+pub fn qemu_socket_transport_is_valid(spdm_trans: u32) -> bool {
+    if !(spdm_trans == SOCKET_TRANSPORT_TYPE_PCI_DOE
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_MCTP
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_SCSI
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_NVME
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_ATA)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_spdm_cmd_is_valid(spdm_cmd: u32) -> bool {
+    if !(spdm_cmd == SOCKET_SPDM_COMMAND_NORMAL
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_SEND
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_RECV
+        || spdm_cmd == SOCKET_SPDM_STORAGE_ACK_STATUS)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_storage_transport_is_valid(spdm_trans: u32) -> bool {
+    if !(spdm_trans == SOCKET_TRANSPORT_TYPE_SCSI
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_NVME
+        || spdm_trans == SOCKET_TRANSPORT_TYPE_ATA)
+    {
+        return false;
+    }
+    true
+}
+
+pub fn qemu_socket_storage_cmd_is_valid(spdm_cmd: u32) -> bool {
+    if !(spdm_cmd == SOCKET_SPDM_STORAGE_IF_SEND
+        || spdm_cmd == SOCKET_SPDM_STORAGE_IF_RECV
+        || spdm_cmd == SOCKET_SPDM_STORAGE_ACK_STATUS)
+    {
+        return false;
+    }
+    true
+}
 
 /// # Summary
 ///
@@ -345,6 +396,773 @@ unsafe extern "C" fn qemu_receive_message_mctp(
 
 /// # Summary
 ///
+/// Get the next incoming storage command from the requester through QEMU.
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `msg_len`: On return, number of bytes received
+/// * `msg_in`: Data buffer to capture incoming command (this must be of sufficient length)
+///
+/// # Returns
+///
+/// Storage Command, only valid types are IF_RECV/IF_SEND.
+pub fn qemu_get_next_storage_cmd(
+    stream: &mut TcpStream,
+    msg_len: &mut usize,
+    msg_in: &mut [u8],
+) -> Option<(u32, u32)> {
+    debug!("Receiving message");
+    // QEMU sends additional information regarding the message
+    // Read them here so they don't go into the SPDM message buffer.
+    let mut buf: [u8; 4] = [0; 4];
+
+    // SPDM Command
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+    let cmd = u32::from_be_bytes(buf);
+    assert!(qemu_socket_storage_cmd_is_valid(cmd));
+
+    // Transport Type
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+    let transport = u32::from_be_bytes(buf);
+    assert!(qemu_socket_storage_transport_is_valid(transport));
+
+    // Receive Size
+    assert_eq!(stream.read(&mut buf).unwrap(), 4);
+
+    let mut read_len = stream.read(msg_in);
+    while read_len.is_err() {
+        read_len = stream.read(msg_in);
+    }
+    let read_len = read_len.unwrap();
+
+    debug!("SPDM Transport Receive: {:x?}", &msg_in[..read_len]);
+
+    if read_len == 0 {
+        // when read() return 0, the two likely cases are:
+        // 1. socket shut down correctly
+        // 2. reader has reached its “end of file” and will likely no longer be
+        //    able to produce bytes
+        warn!("Connection dropped to client, exiting...");
+        std::process::exit(0);
+    }
+
+    assert!(read_len != 0);
+
+    *msg_len = read_len;
+
+    Some((cmd, transport))
+}
+
+/// # Summary
+///
+/// QEMU waits for a status reply for and IF_RECV/IF_SEND that shall be forwarded
+/// back to the requester. This functions acks with `storage_cmd_status`
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+/// * `storage_cmd_status`: Message status type
+///
+/// # Returns
+///
+/// Ok(()) on success
+pub fn qemu_socket_storage_ack_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+    storage_cmd_status: u16,
+) -> Result<(), Errno> {
+    if !qemu_socket_spdm_cmd_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    if !qemu_socket_storage_transport_is_valid(spdm_trans) {
+        return Err(Errno::EINVAL);
+    }
+
+    // Write out the data
+    assert_eq!(stream.write(&spdm_cmd.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(stream.write(&spdm_trans.to_be().to_ne_bytes()).unwrap(), 4);
+
+    // We are only writing back the cmd status
+    let tx_len = core::mem::size_of::<u16>();
+    assert_eq!(
+        stream
+            .write(&(u32::try_from(tx_len).unwrap()).to_be().to_ne_bytes())
+            .unwrap(),
+        4
+    );
+
+    assert_eq!(
+        stream
+            .write(&storage_cmd_status.to_be().to_ne_bytes())
+            .unwrap(),
+        2
+    );
+    stream.flush().unwrap();
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// Write an response message back to QEMU
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+/// * `msg_size`: size of message in bytes
+/// * `msg_buf`: message data buffer
+///
+/// # Returns
+///
+/// Ok(()) on success
+/// Err(Errno) on any failures
+pub fn qemu_socket_xfer_to_requester(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+    msg_size: u32,
+    msg_buf: &[u8],
+) -> Result<(), Errno> {
+    if !qemu_socket_spdm_cmd_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    if !qemu_socket_transport_is_valid(spdm_trans) {
+        return Err(Errno::EINVAL);
+    }
+
+    if msg_size as usize > msg_buf.len() {
+        return Err(Errno::EINVAL);
+    }
+
+    // Write out the data
+    assert_eq!(stream.write(&spdm_cmd.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(stream.write(&spdm_trans.to_be().to_ne_bytes()).unwrap(), 4);
+
+    assert_eq!(stream.write(&msg_size.to_be().to_ne_bytes()).unwrap(), 4);
+
+    stream.write_all(msg_buf).unwrap();
+    stream.flush().unwrap();
+
+    Ok(())
+}
+
+pub fn qemu_ack_invalid_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+) -> Result<(), Errno> {
+    if !qemu_socket_storage_transport_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    match spdm_trans {
+        SOCKET_TRANSPORT_TYPE_NVME => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                NvmeCmdStatus::InvalidFieldInCmd as u16 | NvmeCmdStatus::DoNotRetry as u16,
+            )
+            .unwrap();
+            warn!(
+                "Acked bad message with NVME status: {:?} & {:?} - Code: 0x{:x}",
+                NvmeCmdStatus::InvalidFieldInCmd,
+                NvmeCmdStatus::DoNotRetry,
+                NvmeCmdStatus::InvalidFieldInCmd as u16 | NvmeCmdStatus::DoNotRetry as u16
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_SCSI => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                ScsiAsc::InvalidFieldInCdb as u16,
+            )
+            .unwrap();
+
+            warn!(
+                "Acked bad message with SCSI ASC: {:?}",
+                ScsiAsc::InvalidFieldInCdb
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_ATA => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                AtaStatusErr::InvalidCommand as u16,
+            )
+            .unwrap();
+
+            warn!(
+                "Acked bad message with ATA Status {:?} | ATA Error {:?}",
+                (AtaStatusErr::InvalidCommand as u16) >> 8,
+                (AtaStatusErr::InvalidCommand as u16) & 0xFF
+            );
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// QEMU waits for a status reply for and IF_RECV/IF_SEND that shall be forwarded
+/// back to the requester. This functions acks with NVMe CQE Success.
+///
+/// # Parameter
+///
+/// * `stream`: Socket stream
+/// * `spdm_cmd`: Type of socket message (QEMU Specific)
+/// * `spdm_trans`: SPDM transport type
+///
+/// # Returns
+///
+/// Ok(()) on success
+/// Err(Errno) on any failures
+pub fn qemu_ack_valid_msg(
+    stream: &mut TcpStream,
+    spdm_cmd: u32,
+    spdm_trans: u32,
+) -> Result<(), Errno> {
+    if !qemu_socket_storage_transport_is_valid(spdm_cmd) {
+        return Err(Errno::EINVAL);
+    }
+
+    match spdm_trans {
+        SOCKET_TRANSPORT_TYPE_NVME => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                NvmeCmdStatus::Success as u16,
+            )
+            .unwrap();
+
+            debug!(
+                "Acked message with NVME status: {:?}",
+                NvmeCmdStatus::Success,
+            );
+        }
+        SOCKET_TRANSPORT_TYPE_SCSI => {
+            qemu_socket_storage_ack_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, spdm_trans, 0)
+                .unwrap();
+            debug!("Acked message with status OK");
+        }
+        SOCKET_TRANSPORT_TYPE_ATA => {
+            qemu_socket_storage_ack_msg(
+                stream,
+                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                spdm_trans,
+                AtaStatusErr::Success as u16,
+            )
+            .unwrap();
+            debug!("Acked message with status OK");
+        }
+        _ => unreachable!(),
+    }
+
+    Ok(())
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Clone, Copy)]
+/// This header is defined in QEMU and it extends the libspdm_storage_transport_virtual_header_t
+/// defined in libspdm with the addition of the length field. The length field represents
+/// the allocation length for an IF_RECV, or the message length in an IF_SEND.
+pub struct QemuStorageSpdmTransportHeader {
+    pub security_protocol: u8,
+    pub security_protocol_specific: u16,
+    pub length: u32,
+}
+
+struct QemuStorageTransportHeaderCompact {
+    spsp0_op: u8,
+    length: u32,
+}
+
+fn qemu_storage_decode_transport_header(
+    transport_msg_len: usize,
+    transport_msg: &mut [u8],
+    cmd: u32,
+) -> Result<QemuStorageTransportHeaderCompact, ()> {
+    let mut transport_cmd = 0;
+    if transport_msg_len < std::mem::size_of::<QemuStorageSpdmTransportHeader>() {
+        error!(
+            "Received malformed qemu storage transport header of {transport_msg_len} bytes exepcted {:?} bytes",
+            std::mem::size_of::<QemuStorageSpdmTransportHeader>()
+        );
+        return Err(());
+    }
+    let qemu_hdr = unsafe { *(transport_msg.as_mut_ptr() as *mut QemuStorageSpdmTransportHeader) };
+    // Alias the Qemu header into libspdm_storage_transport_virtual_header_t
+    // Which is the QemuStorageSpdmTransportHeader without the length field.
+    let transport_msg_len = transport_msg_len - std::mem::size_of::<u32>();
+
+    let rc = unsafe {
+        libspdm_transport_storage_decode_management_cmd(
+            transport_msg_len,
+            transport_msg[..transport_msg_len].as_mut_ptr() as *mut c_void,
+            &mut transport_cmd,
+        )
+    };
+
+    if !spdm::LibspdmReturnStatus::libspdm_status_is_success(rc) {
+        error!(
+            "Malformed Storage Transport header: {:x?}",
+            &transport_msg[..transport_msg_len]
+        );
+        error!("libspdm err: 0x{:X}", rc);
+        return Err(());
+    }
+    // Strip the length from QemuStorageSpdmTransportHeader such that this message
+    // starts with libspdm_storage_transport_virtual_header_t and can directly be
+    // passed to libspdm for further processing.
+    transport_msg.copy_within(7.., 3);
+
+    let mut qemu_length: u32 = qemu_hdr.length;
+    qemu_length = if cmd == SOCKET_SPDM_STORAGE_IF_SEND {
+        qemu_length += std::mem::size_of::<libspdm_storage_transport_virtual_header_t>() as u32;
+        qemu_length
+    } else {
+        qemu_length
+    };
+
+    Ok(QemuStorageTransportHeaderCompact {
+        spsp0_op: transport_cmd,
+        length: qemu_length,
+    })
+}
+
+/// # Summary
+///
+/// Sends message to the QEMU by writing the
+/// `message_ptr` data to the TCP stream used by QEMU. This also writes the
+/// additional information expected by QEMU.
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `timeout`: Transaction timeout
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn qemu_send_message_storage(
+    _context: *mut c_void,
+    libspdm_message_size: usize,
+    libspdm_message_ptr: *const c_void,
+    timeout: u64,
+) -> u32 {
+    debug!(
+        "about to send a message of len: {}bytes",
+        libspdm_message_size
+    );
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let message = libspdm_message_ptr as *const u8;
+            let libspdm_msg_buf = unsafe { from_raw_parts(message, libspdm_message_size) };
+
+            if timeout == 0 {
+                stream
+                    .set_write_timeout(None)
+                    .expect("Couldn't set write timeout");
+            } else {
+                stream
+                    .set_write_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set write timeout");
+            }
+            // TODO: Is there a better way to capture incoming commands?
+            //       We are using a bunch of memory here.
+            let mut incoming_msg: [u8; SEND_RECEIVE_BUFFER_LEN] = [0; SEND_RECEIVE_BUFFER_LEN];
+            let mut incoming_msg_len = 0;
+
+            loop {
+                let (cmd, trans_type) =
+                    qemu_get_next_storage_cmd(stream, &mut incoming_msg_len, &mut incoming_msg)
+                        .unwrap();
+                let hdr =
+                    qemu_storage_decode_transport_header(incoming_msg_len, &mut incoming_msg, cmd);
+                if hdr.is_err() {
+                    qemu_ack_invalid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                        .expect("Failed to ack message");
+                    continue;
+                }
+                let hdr = hdr.unwrap();
+                match cmd {
+                    SOCKET_SPDM_STORAGE_IF_SEND => {
+                        // We have an SPDM response to send, but the requester has sent
+                        // us another IF_SEND instead of receiving our pending response
+                        // with IF_RECV. The only valid spdm_storage_operations are
+                        // discovery and pending_info at in this context.
+
+                        // Ack the incoming message if valid
+                        match SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmStorageOperationCodes::Discovery => {
+                                debug!(
+                                    "Storage Transport Discovery Command - Nothing to do (IF_SEND)"
+                                );
+                            }
+                            SpdmStorageOperationCodes::PendingInfo => {
+                                debug!(
+                                    "Handling Storage Transport Pending Info Command - Nothing to do (IF_SEND)"
+                                );
+                                debug!(
+                                    "    - Pending response length: {:} bytes",
+                                    libspdm_message_size
+                                );
+                            }
+                            SpdmStorageOperationCodes::Message
+                            | SpdmStorageOperationCodes::SecMessage => {
+                                error!(
+                                    "Unexpected IF_SEND with {:?}",
+                                    SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap()
+                                );
+                                qemu_ack_invalid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+                                continue;
+                            }
+                        }
+                        // Message was valid, but we had no work to do
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+                    }
+                    SOCKET_SPDM_STORAGE_IF_RECV => {
+                        // This IF_RECV could be for the SPDM response message or a transport
+                        // command
+                        if incoming_msg_len < LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize {
+                            error!("Malformed transport header for IF_RECV!");
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        let mut transport_msg_len = 32;
+                        let mut transport_msg: [u8; 32] = [0; 32];
+
+                        match SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap() {
+                            SpdmStorageOperationCodes::Discovery => {
+                                debug!("Handling Storage Transport Discovery Command (IF_RECV)");
+                                assert!(spdm::LibspdmReturnStatus::libspdm_status_is_success(
+                                    unsafe {
+                                        libspdm_transport_storage_encode_discovery_response(
+                                            &mut transport_msg_len,
+                                            transport_msg.as_mut_ptr() as *mut c_void,
+                                        )
+                                    }
+                                ));
+                            }
+                            SpdmStorageOperationCodes::PendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command (IF_RECV)");
+                                debug!(
+                                    "    - Pending response length: {:} bytes",
+                                    libspdm_message_size
+                                );
+                                assert!(spdm::LibspdmReturnStatus::libspdm_status_is_success(
+                                    unsafe {
+                                        libspdm_transport_storage_encode_pending_info_response(
+                                            &mut transport_msg_len,
+                                            transport_msg.as_mut_ptr() as *mut c_void,
+                                            true,
+                                            u32::try_from(libspdm_message_size).unwrap(),
+                                        )
+                                    }
+                                ));
+                            }
+                            SpdmStorageOperationCodes::Message
+                            | SpdmStorageOperationCodes::SecMessage => {
+                                if (hdr.length as usize) < libspdm_message_size {
+                                    error!(
+                                        "Requester allocation length too small to receive {:?} message.  Minimum required {:}, Got {:}",
+                                        SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap(),
+                                        libspdm_message_size,
+                                        hdr.length
+                                    );
+                                    qemu_ack_valid_msg(
+                                        stream,
+                                        SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                        trans_type,
+                                    )
+                                    .expect("Failed to ack message");
+                                    continue;
+                                }
+                                qemu_ack_valid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+
+                                qemu_socket_xfer_to_requester(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_IF_RECV,
+                                    trans_type,
+                                    u32::try_from(libspdm_message_size).unwrap(),
+                                    libspdm_msg_buf,
+                                )
+                                .expect("failed to write response to requester");
+
+                                debug!("SPDM Send: {:x?}", libspdm_msg_buf);
+                                break;
+                            }
+                        }
+
+                        assert!(transport_msg_len <= transport_msg.len());
+
+                        // A valid transport command request, let's send the response
+                        // generated
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        qemu_socket_xfer_to_requester(
+                            stream,
+                            SOCKET_SPDM_STORAGE_IF_RECV,
+                            trans_type,
+                            u32::try_from(transport_msg_len).unwrap(),
+                            &transport_msg[..transport_msg_len],
+                        )
+                        .expect("failed to write response to requester");
+                    }
+                    _ => unreachable!("Undefined qemu transport management command"),
+                }
+            }
+        }
+        None => {
+            unreachable!("Socket stream lost")
+        }
+    }
+    0
+}
+
+/// # Summary
+///
+/// Receives a message from QEMU into buffer pointed to by
+/// the `message_ptr`. This may block until the socket has data ready. This will
+/// also fetch the additional message data (non-spdm) sent from QEMU.
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `SEND_RECEIVE_BUFFER_LEN` to capture the received bytes.
+/// * `timeout`: Transaction timeout
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn qemu_receive_message_storage(
+    _context: *mut c_void,
+    libspdm_message_size: *mut usize,
+    libspdm_msg_buf_ptr: *mut *mut c_void,
+    timeout: u64,
+) -> u32 {
+    match &mut *CLIENT_CONNECTION.lock().unwrap() {
+        Some(stream) => {
+            let libspdm_message = unsafe { *libspdm_msg_buf_ptr as *mut u8 };
+            // We are using this to cache any incoming temporary data,
+            // When an SPDM message is received, it will be overwritten with that data
+            // before being passed back to libspdm.
+            let libspdm_message_buf =
+                unsafe { from_raw_parts_mut(libspdm_message, SEND_RECEIVE_BUFFER_LEN) };
+
+            if timeout == 0 {
+                stream
+                    .set_read_timeout(None)
+                    .expect("Couldn't set read timeout");
+            } else {
+                stream
+                    .set_read_timeout(Some(Duration::from_micros(timeout)))
+                    .expect("Couldn't set read timeout");
+            }
+
+            let mut incoming_msg_len = 0;
+
+            loop {
+                let (cmd, trans_type) =
+                    qemu_get_next_storage_cmd(stream, &mut incoming_msg_len, libspdm_message_buf)
+                        .unwrap();
+                let hdr = match qemu_storage_decode_transport_header(
+                    incoming_msg_len,
+                    libspdm_message_buf,
+                    cmd,
+                ) {
+                    Ok(h) => h,
+                    Err(_) => {
+                        qemu_ack_invalid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+                        continue;
+                    }
+                };
+                match cmd {
+                    SOCKET_SPDM_STORAGE_IF_SEND => {
+                        // Contextually, we are expecting an IF_SEND with a storage/secure msg.
+                        // But we could also get discovery/pending_info here.
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        let op_code = SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap();
+                        match op_code {
+                            SpdmStorageOperationCodes::Discovery => {
+                                debug!(
+                                    "Storage Transport Discovery Command - Nothing to do (IF_SEND)"
+                                );
+                                continue;
+                            }
+                            SpdmStorageOperationCodes::PendingInfo => {
+                                debug!(
+                                    "Handling Storage Transport Pending Info Command - Nothing to do (IF_SEND)"
+                                );
+                                debug!("    - No pending response!");
+                                continue;
+                            }
+                            SpdmStorageOperationCodes::Message
+                            | SpdmStorageOperationCodes::SecMessage => {
+                                // Received an actual SPDM message
+                                unsafe { *libspdm_message_size = hdr.length as usize };
+                                info!(
+                                    "SPDM Received {:?}: {:x?}",
+                                    op_code,
+                                    &libspdm_message_buf[..(hdr.length as usize)]
+                                );
+                                // The data was received into the memory allocated by libspdm
+                                // no more work to do.
+                                break;
+                            }
+                        };
+                    }
+                    SOCKET_SPDM_STORAGE_IF_RECV => {
+                        // We have no data to return in this context, an IF_RECV should
+                        // only mean that it was a transport Discovery/Pending Info
+                        // command.
+                        let op_code = SpdmStorageOperationCodes::try_from(hdr.spsp0_op).unwrap();
+                        let mut transport_msg = [0u8; TRANSPORT_MSG_BUF_SIZE];
+                        let mut transport_msg_len = TRANSPORT_MSG_BUF_SIZE;
+
+                        if (hdr.length as usize) < transport_msg_len {
+                            error!(
+                                "Requester allocation length too small to receive {:?} message. Minimum required {:?}, Got {:?}",
+                                op_code, transport_msg_len, hdr.length
+                            );
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        let rc = match op_code {
+                            SpdmStorageOperationCodes::Discovery => {
+                                debug!("Handling Storage Transport Discovery Command (IF_RECV)");
+                                unsafe {
+                                    libspdm_transport_storage_encode_discovery_response(
+                                        &mut transport_msg_len,
+                                        transport_msg.as_mut_ptr() as *mut c_void,
+                                    )
+                                }
+                            }
+                            SpdmStorageOperationCodes::PendingInfo => {
+                                debug!("Handling Storage Transport Pending Info Command (IF_RECV)");
+                                debug!("    - No pending response!");
+                                unsafe {
+                                    libspdm_transport_storage_encode_pending_info_response(
+                                        &mut transport_msg_len,
+                                        transport_msg.as_mut_ptr() as *mut c_void,
+                                        false,
+                                        0,
+                                    )
+                                }
+                            }
+                            _ => {
+                                error!("Unexpected IF_RECV with {:?}", op_code);
+                                qemu_ack_invalid_msg(
+                                    stream,
+                                    SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                    trans_type,
+                                )
+                                .expect("Failed to ack message");
+                                continue;
+                            }
+                        };
+
+                        if !spdm::LibspdmReturnStatus::libspdm_status_is_success(rc) {
+                            error!(
+                                "Failed to generate transport response, libspdm err: {:x}",
+                                rc
+                            );
+                            qemu_ack_invalid_msg(
+                                stream,
+                                SOCKET_SPDM_STORAGE_ACK_STATUS,
+                                trans_type,
+                            )
+                            .expect("Failed to ack message");
+                            continue;
+                        }
+
+                        assert!(transport_msg_len <= transport_msg.len());
+
+                        // A valid transport command request, let's send the response
+                        // generated
+                        qemu_ack_valid_msg(stream, SOCKET_SPDM_STORAGE_ACK_STATUS, trans_type)
+                            .expect("Failed to ack message");
+
+                        qemu_socket_xfer_to_requester(
+                            stream,
+                            SOCKET_SPDM_STORAGE_IF_RECV,
+                            trans_type,
+                            u32::try_from(transport_msg_len).unwrap(),
+                            &transport_msg[..transport_msg_len],
+                        )
+                        .expect("Failed to write transport response to requester");
+                    }
+                    _ => unreachable!("Undefined qemu transport management command"),
+                }
+            }
+        }
+        None => {
+            unreachable!("Socket stream lost")
+        }
+    }
+    0
+}
+
+/// # Summary
+///
 /// Registers the SPDM `context` for a `qemu_server` backend.
 ///
 /// # Parameter
@@ -407,7 +1225,13 @@ pub fn register_device(
                     Some(qemu_receive_message_mctp),
                 );
             }
-            TransportLayer::Storage => todo!(),
+            TransportLayer::Storage => {
+                libspdm_register_device_io_func(
+                    context,
+                    Some(qemu_send_message_storage),
+                    Some(qemu_receive_message_storage),
+                );
+            }
         }
         io_buffers::libspdm_setup_io_buffers(
             context,

--- a/src/storage_standards.rs
+++ b/src/storage_standards.rs
@@ -5,7 +5,6 @@
 //! Contains all of the handlers for creating SPDM requests.
 
 /// SCSI SPDM Related ADDITIONAL SENSE CODE (ASQ)
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum ScsiAsc {
     InvalidFieldInCdb = 0x24, // ASCQ = 0x00
@@ -13,7 +12,6 @@ pub enum ScsiAsc {
 
 /// Defines the SPDM return status (upper byte) and error (lower byte)
 /// for ATA as defined in DSP0284.
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum AtaStatusErr {
     Success = 0x5000,
@@ -21,7 +19,6 @@ pub enum AtaStatusErr {
 }
 
 /// NVME Completion Queue Command Completion Status
-#[allow(dead_code)]
 #[derive(Debug)]
 pub enum NvmeCmdStatus {
     Success = 0x0000,


### PR DESCRIPTION
Currently the QEMU server only supports the DoE transport, but QEMU upstream now suppports the SPDM over the storage transport protocol (DSP0286). Add support to the qemu-server in spdm-utils to allow emulating SPDM over the storage transport protocol.

Testing:

Running spdm-utils inside a QEMU VM with QEMU attached to this response server. Then, from the guest issuing SPDM requests to an emulated NVMe controller initialized with `spdm_trans=nvme`.