### PR TITLE
Initial PQC support

### DIFF
--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -288,6 +288,57 @@ pub fn parse_asym_algos(asym_algos: Option<String>) -> Result<u32, ()> {
 
 /// # Summary
 ///
+/// Parses the CLI PQC asymmetric algorithms specified.
+///
+/// If an empty string is specified then no algorithms are enalbed. We default
+/// to enable all.
+///
+/// # Parameter
+///
+/// * `pqc_asym_algo`: An optional comma delimited string containing the PQC algos
+///
+/// # Returns
+///
+/// Returns a `u32` bitmask suitable for `LIBSPDM_DATA_PQC_ASYM_ALGO`, or `Ok(0)` for none.
+pub fn parse_pqc_asym_algos(pqc_asym_algo: Option<String>) -> Result<u32, ()> {
+    let mut specified_algos: u32 = 0;
+    let algos = match pqc_asym_algo.as_deref() {
+        None => {
+            let default = SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_44
+                | SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_65
+                | SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87;
+            debug!("Enabling all PQC Algos: {}", default);
+            return Ok(default);
+        }
+        Some("") => {
+            debug!("All PQC Algos are disabled");
+            return Ok(0);
+        }
+        Some(s) => s
+            .split(',')
+            .map(|elem| elem.trim().to_string())
+            .collect::<Vec<String>>(),
+    };
+
+    for algo in algos {
+        match algo.as_str() {
+            "ML_DSA_44" => specified_algos |= SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_44,
+            "ML_DSA_65" => specified_algos |= SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_65,
+            "ML_DSA_87" => specified_algos |= SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87,
+            "" => {}
+            other => {
+                error!("Unsupported PQC asymmetric algorithm: {}", other);
+                return Err(());
+            }
+        }
+    }
+
+    debug!("Specified PQC Algos: {}", specified_algos);
+    Ok(specified_algos)
+}
+
+/// # Summary
+///
 /// Parses the CLI based hashing algorithms specified
 ///
 /// # Parameter

--- a/src/libspdm/responder.rs
+++ b/src/libspdm/responder.rs
@@ -13,8 +13,17 @@ use alloc::vec::Vec;
 use core::ffi::c_void;
 #[cfg(not(feature = "no_std"))]
 use std::fs;
+use std::fs::OpenOptions;
 #[cfg(not(feature = "no_std"))]
 use std::path::Path;
+#[cfg(not(feature = "no_std"))]
+use std::sync::OnceLock;
+
+/// Certificate model stored by [`register_algs_negotiated_callback`] and
+/// consumed inside [`device_connection_state_callback`]. All other PQC
+/// parameters are read directly from the SPDM context at callback time.
+#[cfg(not(feature = "no_std"))]
+static PQC_CERT_MODE: OnceLock<CertModel> = OnceLock::new();
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CertModel {
@@ -33,6 +42,7 @@ pub enum CertModel {
 /// * `slot_id`: slot id for this session
 /// * `ver`: SPDM Version
 /// * `asym_algo`: Asymmetric algorithm used
+/// * `pqc_asym_algo`: PQC asymmetric algorithm bitmask (SPDM 1.4); 0 means none
 /// * `hash_algo`: Hashing algorithm used
 /// * `heartbeat_period`: Specifies the `HeartbeatPeriod` in units of seconds.
 ///    This value is communicated to the Requester in the `KEY_EXCHANGE_RSP` and
@@ -52,6 +62,7 @@ pub fn setup_capabilities(
     slot_id: u8,
     spdm_ver: Option<&Vec<u16>>,
     asym_algo: u32,
+    pqc_asym_algo: u32,
     hash_algo: u32,
     cert_mode: CertModel,
     heartbeat_period: u8,
@@ -162,6 +173,47 @@ pub fn setup_capabilities(
             data_ptr,
             core::mem::size_of::<u32>(),
         );
+
+        if pqc_asym_algo != 0 {
+            let mut data: u32 = pqc_asym_algo;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_PQC_ASYM_ALGO,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<u32>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_PQC_ASYM_ALGO]");
+                return Err(());
+            }
+
+            let mut data: u32 = pqc_asym_algo;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_REQ_PQC_ASYM_ALG,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<u32>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_PQC_ASYM_ALGO]");
+                return Err(());
+            }
+
+            let mut data: bool = true;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_ALGO_PRIORITY_PQC_FIRST,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<bool>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_ALGO_PRIORITY_PQC_FIRST]");
+                return Err(());
+            }
+        }
 
         let mut data: u16 = SPDM_ALGORITHMS_DHE_NAMED_GROUP_SECP_384_R1 as u16;
         let data_ptr = &mut data as *mut _ as *mut c_void;
@@ -306,6 +358,84 @@ pub fn setup_capabilities(
     Ok(())
 }
 
+/// Returns the `certs/bank-*/` directory name for the given PQC algorithm bitmask.
+fn pqc_bank_dir(pqc_asym_algo: u32) -> &'static str {
+    match pqc_asym_algo {
+        libspdm_rs::SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_44 => "bank-mldsa44",
+        libspdm_rs::SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_65 => "bank-mldsa65",
+        libspdm_rs::SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87 => "bank-mldsa87",
+        _ => panic!("unsupported pqc_asym_algo: 0x{:x}", pqc_asym_algo),
+    }
+}
+
+/// # Summary
+///
+/// Provisions a certificate slot with the PQC cert chain from the matching
+/// `certs/bank-<algo>/` directory.
+///
+/// # Parameter
+///
+/// * `context`: The SPDM context
+/// * `slot_id`: Slot to provision (0–7)
+/// * `pqc_asym_algo`: PQC algorithm bitmask (e.g. `SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87`)
+/// * `hash_algo`: Hash algorithm bitmask used for the cert-chain header digest
+/// * `cert_mode`: Alias or Device cert model
+///
+/// # Returns
+///
+/// `Ok(())` on success, `Err(())` otherwise.
+#[cfg(not(feature = "no_std"))]
+pub fn setup_pqc_cert_bank(
+    context: *mut c_void,
+    slot_id: u8,
+    pqc_asym_algo: u32,
+    hash_algo: u32,
+    cert_mode: CertModel,
+) -> Result<(), ()> {
+    let bank = pqc_bank_dir(pqc_asym_algo);
+    let file_path = if cert_mode == CertModel::Alias {
+        format!(
+            "certs/{}/alias/slot{}/bundle_responder.certchain.der",
+            bank, slot_id
+        )
+    } else {
+        format!(
+            "certs/{}/device/slot{}/bundle_responder.certchain.der",
+            bank, slot_id
+        )
+    };
+
+    let path = Path::new(&file_path);
+    let buffer = match fs::read(path) {
+        Err(why) => {
+            error!("couldn't open {}: {}", path.display(), why);
+            return Err(());
+        }
+        Ok(data) => data,
+    };
+
+    let (cert_chain_buffer, cert_chain_size) =
+        unsafe { get_local_certchain(&buffer, 0, hash_algo, false) };
+    let parameter = libspdm_data_parameter_t::new_local(slot_id);
+    if LibspdmReturnStatus::libspdm_status_is_error(unsafe {
+        libspdm_set_data(
+            context,
+            libspdm_data_type_t_LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN,
+            &parameter as *const libspdm_data_parameter_t,
+            cert_chain_buffer,
+            cert_chain_size,
+        )
+    }) {
+        error!(
+            "Failed to set PQC [LIBSPDM_DATA_LOCAL_PUBLIC_CERT_CHAIN] for slot {}",
+            slot_id
+        );
+        return Err(());
+    }
+
+    Ok(())
+}
+
 /// # Summary
 ///
 /// Sets the SupportedSlotMask to indicate that the certificate slots described by,
@@ -363,6 +493,160 @@ pub fn set_supported_slots_mask(
         return Ok(());
     }
     Err(())
+}
+
+/// Callback invoked by libspdm on every connection-state transition.
+///
+/// This is currently used to implement the SPDM Banked Architecture once
+/// `LIBSPDM_CONNECTION_STATE_NEGOTIATED` is reached. If a PQC algorithm was
+/// selected the PQC certificate chain is loaded into the slot designated
+/// during [`register_algs_negotiated_callback`]. This is used to emulate
+/// the banked architecture in SPDM 1.4.
+/// ECC sessions need no action because ECC chains are provisioned upfront.
+///
+/// # Safety
+///
+/// Called directly by libspdm with a valid `spdm_context`.
+#[cfg(not(feature = "no_std"))]
+pub unsafe extern "C" fn device_connection_state_callback(
+    spdm_context: *mut c_void,
+    connection_state: libspdm_connection_state_t,
+) {
+    if connection_state != libspdm_connection_state_t_LIBSPDM_CONNECTION_STATE_NEGOTIATED {
+        return;
+    }
+
+    let conn = libspdm_data_parameter_t {
+        location: 1, // LIBSPDM_DATA_LOCATION_CONNECTION
+        additional_data: [0; 4],
+    };
+
+    // PQC algorithms are only available in SPDM 1.4+.
+    let mut spdm_version: u16 = 0;
+    let mut data_size = core::mem::size_of::<u16>();
+    unsafe {
+        libspdm_get_data(
+            spdm_context,
+            libspdm_data_type_t_LIBSPDM_DATA_SPDM_VERSION,
+            &conn as *const libspdm_data_parameter_t,
+            &mut spdm_version as *mut _ as *mut c_void,
+            &mut data_size,
+        );
+    }
+    spdm_version = spdm_version >> 8;
+
+    if spdm_version < SPDM_MESSAGE_VERSION_14 as u16 {
+        debug!(
+            "device_connection_state_callback: SPDM 0x{:04x} < 1.4, skipping PQC",
+            spdm_version
+        );
+        return;
+    }
+
+    // Read negotiated PQC asymmetric algorithm.
+    let mut pqc_asym_algo: u32 = 0;
+    data_size = core::mem::size_of::<u32>();
+    let ret = unsafe {
+        libspdm_get_data(
+            spdm_context,
+            libspdm_data_type_t_LIBSPDM_DATA_PQC_ASYM_ALGO,
+            &conn as *const libspdm_data_parameter_t,
+            &mut pqc_asym_algo as *mut _ as *mut c_void,
+            &mut data_size,
+        )
+    };
+    debug!(
+        "device_connection_state_callback: PQC_ASYM_ALGO ret=0x{:x} algo=0x{:x}",
+        ret, pqc_asym_algo
+    );
+    if pqc_asym_algo == 0 {
+        debug!("device_connection_state_callback: ECC negotiated, nothing to do");
+        return;
+    }
+
+    // Read negotiated base hash algorithm.
+    let mut hash_algo: u32 = 0;
+    data_size = core::mem::size_of::<u32>();
+    unsafe {
+        libspdm_get_data(
+            spdm_context,
+            libspdm_data_type_t_LIBSPDM_DATA_BASE_HASH_ALGO,
+            &conn as *const libspdm_data_parameter_t,
+            &mut hash_algo as *mut _ as *mut c_void,
+            &mut data_size,
+        );
+    }
+
+    let cert_mode = match PQC_CERT_MODE.get() {
+        Some(m) => *m,
+        None => {
+            error!("device_connection_state_callback: PQC_CERT_MODE not initialised");
+            return;
+        }
+    };
+
+    let bank = pqc_bank_dir(pqc_asym_algo);
+    let mut num_provisioned_slots = 0;
+
+    for slot_id in 1..8 {
+        let file_name = if cert_mode == CertModel::Alias {
+            format!(
+                "certs/{}/alias/slot{}/bundle_responder.certchain.der",
+                bank, slot_id
+            )
+        } else {
+            format!(
+                "certs/{}/device/slot{}/bundle_responder.certchain.der",
+                bank, slot_id
+            )
+        };
+        let path = Path::new(&file_name);
+
+        if OpenOptions::new()
+            .read(true)
+            .write(false)
+            .open(path)
+            .is_ok()
+        {
+            setup_pqc_cert_bank(spdm_context, slot_id, pqc_asym_algo, hash_algo, cert_mode)
+                .unwrap();
+            num_provisioned_slots += 1;
+        }
+    }
+
+    setup_pqc_cert_bank(spdm_context, 0, pqc_asym_algo, hash_algo, cert_mode).unwrap();
+    num_provisioned_slots += 1;
+
+    let mut spdm_ver = Vec::new();
+    spdm_ver.push(spdm_version);
+
+    set_supported_slots_mask(num_provisioned_slots, &spdm_ver, spdm_context)
+        .map_err(|_| {
+            error!("failed to set supported slot mask");
+        })
+        .unwrap();
+}
+
+/// Register [`device_connection_state_callback`] with libspdm and record the
+/// certificate model so the callback can select the correct cert path.
+/// All other PQC parameters (`hash_algo`, `pqc_slot`) are read directly from
+/// the SPDM context at callback time.
+///
+/// # Parameter
+///
+/// * `context`   - The SPDM context.
+/// * `cert_mode` - Certificate chain model (alias or device).
+#[cfg(not(feature = "no_std"))]
+pub fn register_algs_negotiated_callback(context: *mut c_void, cert_mode: CertModel) {
+    if let Err(e) = PQC_CERT_MODE.set(cert_mode) {
+        error!("Unable to set the PQC certificate mode {e:?}");
+    }
+    unsafe {
+        libspdm_register_connection_state_callback_func(
+            context,
+            Some(device_connection_state_callback),
+        );
+    }
 }
 
 /// # Summary

--- a/src/libspdm/spdm.rs
+++ b/src/libspdm/spdm.rs
@@ -1173,7 +1173,7 @@ pub unsafe extern "C" fn libspdm_responder_data_sign(
     _key_pair_id: u8,
     op_code: u8,
     base_asym_algo: u32,
-    _pqc_asym_algo: u32,
+    pqc_asym_algo: u32,
     base_hash_algo: u32,
     is_data_hash: bool,
     message: *const u8,
@@ -1182,6 +1182,75 @@ pub unsafe extern "C" fn libspdm_responder_data_sign(
     sig_size: *mut usize,
 ) -> bool {
     let mut context: *mut c_void = ptr::null_mut();
+
+    #[cfg(not(feature = "no_std"))]
+    if pqc_asym_algo != 0 {
+        let key_path = match pqc_asym_algo {
+            libspdm_rs::SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87 => {
+                "certs/bank-mldsa87/slot0/end_responder.key"
+            }
+            _ => panic!("unsupported pqc_asym_algo: 0x{:x}", pqc_asym_algo),
+        };
+
+        let path = Path::new(key_path);
+        let buffer = fs::read(path).expect("couldn't open PQC responder key");
+        let buffer_len = buffer.len();
+        let key_buffer_layout = Layout::from_size_align(buffer_len, 8).unwrap();
+        let key_buffer = unsafe { alloc(key_buffer_layout) };
+        unsafe { key_buffer.copy_from(buffer.as_ptr(), buffer_len) };
+
+        let result = unsafe {
+            libspdm_pqc_asym_get_private_key_from_pem(
+                pqc_asym_algo,
+                key_buffer,
+                buffer_len,
+                ptr::null_mut(),
+                &mut context,
+            )
+        };
+        if !result {
+            unsafe { key_buffer.write_bytes(0, buffer_len) };
+            unsafe { dealloc(key_buffer, key_buffer_layout) };
+            return false;
+        }
+
+        let result = if is_data_hash {
+            unsafe {
+                libspdm_pqc_asym_sign_hash(
+                    spdm_version,
+                    op_code,
+                    pqc_asym_algo,
+                    base_hash_algo,
+                    context,
+                    message,
+                    message_size,
+                    signature,
+                    sig_size,
+                )
+            }
+        } else {
+            unsafe {
+                libspdm_pqc_asym_sign(
+                    spdm_version,
+                    op_code,
+                    pqc_asym_algo,
+                    base_hash_algo,
+                    context,
+                    message,
+                    message_size,
+                    signature,
+                    sig_size,
+                )
+            }
+        };
+
+        unsafe { libspdm_pqc_asym_free(pqc_asym_algo, context) };
+        unsafe { key_buffer.write_bytes(0, buffer_len) };
+        unsafe { dealloc(key_buffer, key_buffer_layout) };
+
+        return result;
+    }
+
     let buffer;
 
     #[cfg(feature = "no_std")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,6 +220,20 @@ enum Commands {
         #[arg(long, default_value = "ECDSA_ECC_NIST_P384")]
         asym_algos: Option<String>,
 
+        /// Supported PQC asymmetric algorithm
+        ///
+        /// Multiple algorithms may be specified in this form
+        /// [ML_DSA_44,ML_DSA_65,ML_DSA_87]
+        ///
+        /// The default is enabled all, PQC can be disabled
+        /// with an empty string.
+        ///
+        /// ML_DSA_44
+        /// ML_DSA_65
+        /// ML_DSA_87
+        #[arg(long)]
+        pqc_asym_algo: Option<String>,
+
         /// Supported hashing algorithms
         ///
         /// Multiple algorithms may be specified in this form
@@ -805,6 +819,7 @@ async fn main() -> Result<(), ()> {
             cert_slot_id,
             cert_path,
             asym_algos,
+            pqc_asym_algo,
             hash_algos,
             dhe_named_groups,
             aead_cipher_suites,
@@ -814,6 +829,7 @@ async fn main() -> Result<(), ()> {
                 cntx_ptr,
                 slot_id,
                 cli_helpers::parse_asym_algos(asym_algos)?,
+                cli_helpers::parse_pqc_asym_algos(pqc_asym_algo)?,
                 cli_helpers::parse_hash_algos(hash_algos)?,
                 cli_helpers::parse_dhe_named_groups(dhe_named_groups)?,
                 cli_helpers::parse_aead_cipher_suite(aead_cipher_suites)?,
@@ -913,6 +929,7 @@ async fn main() -> Result<(), ()> {
                         slot_id,
                         None,
                         SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
+                        SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87,
                         SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384,
                         model,
                         1,
@@ -926,6 +943,7 @@ async fn main() -> Result<(), ()> {
                 0,
                 Some(&spdm_ver),
                 SPDM_ALGORITHMS_BASE_ASYM_ALGO_TPM_ALG_ECDSA_ECC_NIST_P384,
+                SPDM_ALGORITHMS_PQC_ASYM_ALGO_ML_DSA_87,
                 SPDM_ALGORITHMS_BASE_HASH_ALGO_TPM_ALG_SHA_384,
                 model,
                 1,
@@ -936,6 +954,12 @@ async fn main() -> Result<(), ()> {
                 .map_err(|_| {
                     error!("failed to set supported slot mask");
                 })?;
+
+            if certificate_model == "alias" {
+                responder::register_algs_negotiated_callback(cntx_ptr, CertModel::Alias);
+            } else {
+                responder::register_algs_negotiated_callback(cntx_ptr, CertModel::Device);
+            }
 
             // We need to make sure the hashes are generated before starting the
             // response loop

--- a/src/request.rs
+++ b/src/request.rs
@@ -34,6 +34,7 @@ const LIBSPDM_STATUS_INVALID_CERT: u32 = 0x80030000;
 /// * `context`: The SPDM context
 /// * `slot_id`: slot id for this session
 /// * `asym_algo`: Asymmetric algorithm used
+/// * `pqc_asym_algo`: PQC asymmetric algorithm bitmask (SPDM 1.4); 0 means none
 /// * `hash_algo`: Hashing algorithm used
 ///
 /// # Returns
@@ -49,6 +50,7 @@ pub fn setup_capabilities(
     context: *mut c_void,
     slot_id: u8,
     asym_algo: u32,
+    pqc_asym_algo: u32,
     hash_algo: u32,
     dhe_groups: u16,
     aead_cipher_suites: u16,
@@ -120,6 +122,48 @@ pub fn setup_capabilities(
             data_ptr,
             core::mem::size_of::<u32>(),
         );
+
+        if pqc_asym_algo != 0 {
+            let mut data: u32 = pqc_asym_algo;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_PQC_ASYM_ALGO,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<u32>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_PQC_ASYM_ALGO]");
+                return Err(());
+            }
+
+            let mut data: u32 = pqc_asym_algo;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_REQ_PQC_ASYM_ALG,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<u32>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_PQC_ASYM_ALGO]");
+                return Err(());
+            }
+
+            // If PQC was set, default to using PQC if we can
+            let mut data: bool = true;
+            let data_ptr = &mut data as *mut _ as *mut c_void;
+            if LibspdmReturnStatus::libspdm_status_is_error(libspdm_set_data(
+                context,
+                libspdm_data_type_t_LIBSPDM_DATA_ALGO_PRIORITY_PQC_FIRST,
+                &parameter as *const libspdm_data_parameter_t,
+                data_ptr,
+                core::mem::size_of::<bool>(),
+            )) {
+                error!("Failed to set [LIBSPDM_DATA_ALGO_PRIORITY_PQC_FIRST]");
+                return Err(());
+            }
+        }
 
         let mut data: u16 = dhe_groups;
         let data_ptr = &mut data as *mut _ as *mut c_void;

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -55,6 +55,7 @@ pub fn setup_test_backend(cntx: *mut c_void) -> Result<SpdmSessionInfo, u32> {
         cntx,
         slot_id,
         cli_helpers::parse_asym_algos(Some("ECDSA_ECC_NIST_P384".to_string())).unwrap(),
+        cli_helpers::parse_pqc_asym_algos(Some("ML_DSA_87".to_string())).unwrap(),
         cli_helpers::parse_hash_algos(Some("SHA_384".to_string())).unwrap(),
         cli_helpers::parse_dhe_named_groups(Some("SECP_384_R1,SECP_521_R1".to_string())).unwrap(),
         cli_helpers::parse_aead_cipher_suite(Some("AES_256_GCM".to_string())).unwrap(),


### PR DESCRIPTION
SPDM 1.4 introduces support for PQC using banked certificate slots. This patch adds support for ML-DSA-87 PQC certificates in a second bank. This allows a responder and requester to negotiate and use a PQC algorithm.

Note that any PQC algorithm should work, but we currently just generate ML-DSA-87 certs, the same way we currently only generate ECC-P384 certs to keep things simple.

When running a responder that supports SPDM 1.4

```shell
cargo run -- --socket-server response --spdm-ver 1.4
```

The responder will automatically support ML-DSA-87 and ECC-P384. ECC-P384 is set by default, but if the requester supports ML-DSA-87 that will be used with priority. Support for any other algorithms can be added in the future as required (and should be easy enough).

The requester will also default to supporting PQC. The PQC algorithms can be enabled/disabled by the command line, but we default to all ML-DSA-* being supported.

For example:

```shell
cargo run -- --socket-client request --pqc-asym-algo ML_DSA_87  GET_CERTIFICATE
```

will connect to the responder above, as will

```shell
cargo run -- --socket-client request GET_CERTIFICATE
```

While this will connect, but not using PQC

```shell
cargo run -- --socket-client request --pqc-asym-algo "" GET_CERTIFICATE
```