### PR TITLE
build: add conditional compile for transports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,7 @@ dependencies = [
  "bindgen",
  "clap",
  "colored",
+ "const_format",
  "env_logger",
  "futures",
  "inquire",
@@ -316,6 +317,27 @@ checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -694,6 +716,21 @@ name = "itoa"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+
+[[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
 name = "lazy_static"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ readme = "README.md"
 [features]
 default = ["std"]
 libspdm_tests = []
+pci = []
+nvme = []
 
 no_std = []
 std = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ bindgen = "0.72.0"
 which = "6.0.0"
 
 [dependencies]
+const_format = "0.2.36"
 log = "0.4"
 serialport = { version = "4.3.0", optional = true }
 lazy_static = { version = "1.4.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -49,7 +49,10 @@ See LICENSE-APACHE, LICENSE-MIT, and COPYRIGHT for details.
 
 First you need to install Rust, instructions for that are available at: https://rustup.rs/
 
-You will also need a few host dependencies
+You will also need a few host dependencies, the commands below contain all the
+dependencies needed by `spdm-utils` to enable all supported transports.
+However, `spdm-utils` can be built with only the desired transports enabled,
+see the `Building` section.
 
 ## Fedora or Ubuntu Based
 
@@ -163,6 +166,23 @@ This is currently a work in progress
 
 ```shell
 cargo build --lib --features=no_std
+```
+
+## Build with specific transports enabled
+
+`spdm-utils` suppports building the binary with two transport options, `doe`
+and `nvme`. Which means you can install only the dependencies needed by those
+transports and build the binary as below. Note, we enable other transports that
+do not have external dependecies.
+
+```shell
+# To build with PCI DoE transport support
+$ cargo build --features pci
+
+or
+
+# To build with Storage NVMe transport support
+$ cargo build --features nvme
 ```
 
 ## Configuring the Logger

--- a/build.rs
+++ b/build.rs
@@ -19,8 +19,13 @@ fn main() {
     // so we manually pass the arguments
     println!("cargo:rustc-link-arg=-Wl,--start-group");
 
-    println!("cargo:rustc-link-arg=-lpci");
-    println!("cargo:rustc-link-arg=-lnvme");
+    if cfg!(feature = "pci") {
+        println!("cargo:rustc-link-arg=-lpci");
+    }
+
+    if cfg!(feature = "nvme") {
+        println!("cargo:rustc-link-arg=-lnvme");
+    }
 
     println!("cargo:rustc-link-arg=-lmemlib");
     println!("cargo:rustc-link-arg=-lmalloclib");
@@ -65,6 +70,14 @@ fn main() {
 
     if cfg!(feature = "std") {
         builder = builder.clang_arg("-DRUST_STD");
+
+        if cfg!(feature = "pci") {
+            builder = builder.clang_arg("-DPCI");
+        }
+
+        if cfg!(feature = "nvme") {
+            builder = builder.clang_arg("-DNVME");
+        }
     }
 
     if let Ok(sysroot) = env::var("STAGING_DIR") {

--- a/src/cli_helpers.rs
+++ b/src/cli_helpers.rs
@@ -4,8 +4,10 @@
 
 //! Contains helper functions used in parsing the CLI arguments
 
+#[cfg(feature = "pci")]
 use crate::doe_pci_cfg::PcieDevInfo;
 use crate::*;
+#[cfg(feature = "pci")]
 use inquire::Select;
 
 /// # Summary
@@ -21,6 +23,7 @@ use inquire::Select;
 ///
 /// On success, OK(index) where the index maps to a device in `doe_device`
 /// On any failure, returns an error
+#[cfg(feature = "pci")]
 pub fn pcie_devices_user_select(doe_devices: &[PcieDevInfo]) -> Result<usize, ()> {
     let choice = Select::new("Select a PCIe DoE compatible device:", doe_devices.to_vec()).prompt();
     match choice {
@@ -49,6 +52,7 @@ pub fn pcie_devices_user_select(doe_devices: &[PcieDevInfo]) -> Result<usize, ()
 /// # Returns
 ///
 /// On success, OK((vid, dev_id)) or Err(()) on failure to parse.
+#[cfg(feature = "pci")]
 pub fn parse_pcie_identifiers(vid: String, dev_id: String) -> Result<(u16, u16), ()> {
     fn parse_identifier(id: String, id_type: &str) -> Result<u16, ()> {
         let (id, base) = if id.starts_with("0x") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,37 @@ mod tcg_concise_evidence_binding;
 mod test_suite;
 mod usb_i2c;
 
+use const_format::formatcp;
+
+#[cfg(not(feature = "nvme"))]
+const NVME_MSG: &str = "  - NVMe support (compile with --features nvme)\n";
+#[cfg(feature = "nvme")]
+const NVME_MSG: &str = "";
+
+#[cfg(not(feature = "pci"))]
+const PCI_MSG: &str = "  - PCI/DOE support (compile with --features pci)\n";
+#[cfg(feature = "pci")]
+const PCI_MSG: &str = "";
+
+const DISABLED_FEATURES: &str = formatcp!(
+    "{}{}{}",
+    if cfg!(all(feature = "nvme", feature = "pci")) {
+        ""
+    } else {
+        "DISABLED FEATURES:\n"
+    },
+    NVME_MSG,
+    PCI_MSG
+);
+
 #[derive(Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(
+    author,
+    version,
+    about,
+    long_about = None,
+    after_help = DISABLED_FEATURES
+)]
 struct Args {
     #[command(subcommand)]
     command: Commands,

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,8 +28,10 @@ use once_cell::sync::Lazy;
 pub static SOCKET_PATH: &str = "SPDM-Utils-loopback-socket";
 
 mod cli_helpers;
+#[cfg(feature = "pci")]
 mod doe_pci_cfg;
 mod io_buffers;
+#[cfg(feature = "nvme")]
 mod nvme;
 mod qemu_server;
 mod request;
@@ -47,27 +49,33 @@ struct Args {
     command: Commands,
 
     /// Use NVMe commands for the target device
+    #[cfg(feature = "nvme")]
     #[arg(short, long, requires_ifs([("true", "blk_dev_path")]))]
     nvme: bool,
 
     /// NVME NameSpace Identifier
+    #[cfg(feature = "nvme")]
     #[arg(long, default_value_t = 1)]
     nsid: u32,
 
     /// Path to the block device
+    #[cfg(feature = "nvme")]
     #[arg(long)]
     blk_dev_path: Option<String>,
 
     /// Use the Linux PCIe extended configuration backend
     /// This is generally run on the Linux host machine
+    #[cfg(feature = "pci")]
     #[arg(short, long)]
     doe_pci_cfg: bool,
 
     /// PCIe Identifier, Vendor ID of the SPDM supported device
+    #[cfg(feature = "pci")]
     #[arg(long, default_value = "")]
     pcie_vid: String,
 
     /// PCIe Identifier, Device ID of the SPDM supported device
+    #[cfg(feature = "pci")]
     #[arg(long, default_value = "")]
     pcie_devid: String,
 
@@ -680,10 +688,12 @@ async fn main() -> Result<(), ()> {
 
     let mut count = 0;
 
+    #[cfg(feature = "nvme")]
     cli.nvme.then(|| {
         count += 1;
     });
 
+    #[cfg(feature = "pci")]
     cli.doe_pci_cfg.then(|| {
         count += 1;
     });
@@ -705,37 +715,28 @@ async fn main() -> Result<(), ()> {
         return Err(());
     }
 
-    if (cli.doe_pci_cfg || cli.usb_i2c) && u32::from(geteuid()) != 0 {
-        error!("This transport operation requires root privileges");
-        return Err(());
+    if u32::from(geteuid()) != 0 {
+        let mut need_root = false;
+        #[cfg(feature = "pci")]
+        if cli.doe_pci_cfg {
+            need_root = true;
+        }
+        #[cfg(feature = "nvme")]
+        if cli.nvme {
+            need_root = true;
+        }
+
+        if cli.usb_i2c {
+            need_root = true;
+        }
+
+        if need_root {
+            error!("This transport operation requires root privileges");
+            return Err(());
+        }
     }
 
-    if cli.doe_pci_cfg {
-        unsafe {
-            let (vid, dev_id) = if cli.pcie_vid.is_empty() && cli.pcie_devid.is_empty() {
-                // Try to detect and list devices with DoE support.
-                let doe_support_devs = doe_pci_cfg::get_doe_supported_devs();
-                if doe_support_devs.is_none() {
-                    error!("No DoE supported PCIe devices found");
-                    return Err(());
-                }
-                let doe_support_devs = doe_support_devs.unwrap();
-                let selected_dev_index = cli_helpers::pcie_devices_user_select(&doe_support_devs)?;
-                (
-                    doe_support_devs[selected_dev_index].vendor_id,
-                    doe_support_devs[selected_dev_index].device_id,
-                )
-            } else {
-                let (vid, dev_id) =
-                    cli_helpers::parse_pcie_identifiers(cli.pcie_vid, cli.pcie_devid)?;
-                // In an error case, `get_pcie_dev` will clean up
-                let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(vid, dev_id)?;
-                pci_cleanup(pacc);
-                (vid, dev_id)
-            };
-            doe_pci_cfg::register_device(cntx_ptr, vid, dev_id)?;
-        }
-    } else if cli.socket_server {
+    if cli.socket_server {
         socket_server::register_device(cntx_ptr, cli.server_persist)?;
     } else if cli.socket_client {
         socket_client::register_device(cntx_ptr)?;
@@ -748,14 +749,6 @@ async fn main() -> Result<(), ()> {
         }
 
         usb_i2c::register_device(cntx_ptr, cli.usb_i2c_dev, cli.usb_i2c_baud)?;
-    } else if cli.nvme {
-        if let Err(e) = nvme::nvme_get_sec_info(&cli.blk_dev_path.clone().unwrap(), cli.nsid) {
-            if e == Errno::ENOTSUP {
-                error!("SPDM is not supported by this NVMe device");
-            }
-            return Err(());
-        }
-        nvme::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap(), cli.nsid).unwrap();
     } else if cli.qemu_server {
         if let Commands::Request { .. } = cli.command {
             error!("QEMU Server does not support running an SPDM requester");
@@ -768,8 +761,51 @@ async fn main() -> Result<(), ()> {
             qemu_server::register_device(cntx_ptr, cli.qemu_port, spdm::TransportLayer::Doe)?;
         }
     } else {
-        error!("No supported backend specified");
-        return Err(());
+        #[cfg(feature = "pci")]
+        if cli.doe_pci_cfg {
+            unsafe {
+                let (vid, dev_id) = if cli.pcie_vid.is_empty() && cli.pcie_devid.is_empty() {
+                    // Try to detect and list devices with DoE support.
+                    let doe_support_devs = doe_pci_cfg::get_doe_supported_devs();
+                    if doe_support_devs.is_none() {
+                        error!("No DoE supported PCIe devices found");
+                        return Err(());
+                    }
+                    let doe_support_devs = doe_support_devs.unwrap();
+                    let selected_dev_index =
+                        cli_helpers::pcie_devices_user_select(&doe_support_devs)?;
+                    (
+                        doe_support_devs[selected_dev_index].vendor_id,
+                        doe_support_devs[selected_dev_index].device_id,
+                    )
+                } else {
+                    let (vid, dev_id) =
+                        cli_helpers::parse_pcie_identifiers(cli.pcie_vid, cli.pcie_devid)?;
+                    // In an error case, `get_pcie_dev` will clean up
+                    let (pacc, _, _) = doe_pci_cfg::get_pcie_dev(vid, dev_id)?;
+                    pci_cleanup(pacc);
+                    (vid, dev_id)
+                };
+                doe_pci_cfg::register_device(cntx_ptr, vid, dev_id)?;
+            }
+        }
+
+        #[cfg(feature = "nvme")]
+        if cli.nvme {
+            if let Err(e) = nvme::nvme_get_sec_info(&cli.blk_dev_path.clone().unwrap(), cli.nsid) {
+                if e == Errno::ENOTSUP {
+                    error!("SPDM is not supported by this NVMe device");
+                }
+                return Err(());
+            }
+            nvme::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap(), cli.nsid).unwrap();
+        }
+
+        #[cfg(not(any(feature = "nvme", feature = "pci")))]
+        {
+            error!("No supported backend specified");
+            return Err(());
+        }
     }
 
     unsafe {
@@ -782,19 +818,24 @@ async fn main() -> Result<(), ()> {
                 spdm::TransportLayer::Mctp,
                 spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
             )?;
-        } else if cli.nvme {
-            spdm::setup_transport_layer(
-                cntx_ptr,
-                spdm::TransportLayer::Storage,
-                spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
-            )
-            .unwrap();
         } else {
-            spdm::setup_transport_layer(
-                cntx_ptr,
-                spdm::TransportLayer::Doe,
-                spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
-            )?;
+            #[cfg(feature = "nvme")]
+            if cli.nvme {
+                spdm::setup_transport_layer(
+                    cntx_ptr,
+                    spdm::TransportLayer::Storage,
+                    spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
+                )?;
+            }
+
+            #[cfg(not(feature = "nvme"))]
+            {
+                spdm::setup_transport_layer(
+                    cntx_ptr,
+                    spdm::TransportLayer::Doe,
+                    spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
+                )?;
+            }
         }
     }
 
@@ -951,13 +992,19 @@ async fn main() -> Result<(), ()> {
             responder::response_loop(cntx_ptr);
         }
         Commands::Tests => {
-            if cli.doe_pci_cfg {
-                test_suite::start_tests(cntx_ptr, test_suite::TestBackend::DoeBackend);
-            } else if cli.socket_server || cli.socket_client {
+            if cli.socket_server || cli.socket_client {
                 test_suite::start_tests(cntx_ptr, test_suite::TestBackend::SocketBackend);
             } else {
-                error!("The backend is not supported for testing");
-                return Err(());
+                #[cfg(feature = "pci")]
+                if cli.doe_pci_cfg {
+                    test_suite::start_tests(cntx_ptr, test_suite::TestBackend::DoeBackend);
+                }
+
+                #[cfg(not(feature = "pci"))]
+                {
+                    error!("Testing not supported for this backend");
+                    return Err(());
+                }
             }
         }
     }

--- a/src/test_suite.rs
+++ b/src/test_suite.rs
@@ -12,6 +12,7 @@
 
 use crate::RequestCode;
 use crate::cli_helpers;
+#[cfg(feature = "pci")]
 use crate::doe_pci_cfg::*;
 use crate::request;
 use crate::spdm;
@@ -32,6 +33,7 @@ use std::process::Command;
 
 /// Defines the type of backend to be used in testing
 pub enum TestBackend {
+    #[cfg(feature = "pci")]
     DoeBackend,
     SocketBackend,
 }
@@ -507,6 +509,7 @@ pub fn test_set_certificate(cntx: *mut c_void, cert_slot_id: u8) -> Result<(), (
 /// Does not return, the process will exit after tests are complete.
 pub fn start_tests(cntx: *mut c_void, backend: TestBackend) -> ! {
     match backend {
+        #[cfg(feature = "pci")]
         TestBackend::DoeBackend => {
             // Run DOE conformance tests
             test_discovery_basic().unwrap();

--- a/wrapper.h
+++ b/wrapper.h
@@ -3,9 +3,13 @@
 // Copyright (C) 2022, Western Digital Corporation or its affiliates.
 
 #ifdef RUST_STD
+#ifdef PCI
 #include <pci/pci.h>
+#endif //PCI
+#ifdef NVME
 #include <libnvme.h>
-#endif
+#endif // NVME
+#endif // RUST_STD
 
 #include <library/spdm_common_lib.h>
 #include <library/spdm_crypt_lib.h>


### PR DESCRIPTION
Currently `spdm-utils` build with all transport enabled, which means the users will need to make sure all dependencies are installed libnvme, libpci etc...

Instead, allow these transports to be enabled at compile time with the respective flags.