### PR TITLE
transport: storage: add scsi support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["std"]
 libspdm_tests = []
 pci = []
 nvme = []
+scsi = []
 
 no_std = []
 std = [

--- a/README.md
+++ b/README.md
@@ -169,10 +169,10 @@ cargo build --lib --features=no_std
 
 ## Build with specific transports enabled
 
-`spdm-utils` suppports building the binary with two transport options, `doe`
-and `nvme`. Which means you can install only the dependencies needed by those
-transports and build the binary as below. Note, we enable other transports that
-do not have external dependecies.
+`spdm-utils` suppports building the binary with three transport options, `doe`,
+`scsi` and `nvme`. Which means you can install only the dependencies needed by
+those transports and build the binary as below. Note, we enable other transports
+that do not have external dependecies.
 
 ```shell
 # To build with PCI DoE transport support
@@ -182,6 +182,9 @@ or
 
 # To build with Storage NVMe transport support
 $ cargo build --features nvme
+
+# To build with SCSI and NVMe support
+$ cargo build --features nvme,scsi
 ```
 
 ## Configuring the Logger

--- a/build.rs
+++ b/build.rs
@@ -79,6 +79,10 @@ fn main() {
         if cfg!(feature = "nvme") {
             builder = builder.clang_arg("-DNVME");
         }
+
+        if cfg!(feature = "scsi") {
+            builder = builder.clang_arg("-DSCSI");
+        }
     }
 
     if let Ok(sysroot) = env::var("STAGING_DIR") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,6 +11,7 @@
 use clap::{Parser, Subcommand};
 use futures::future::join_all;
 use libspdm::libspdm_rs::*;
+use nix::errno::Errno;
 use nix::unistd::geteuid;
 use sha2::{Digest, Sha256, Sha384, Sha512};
 use std::fs::File;
@@ -22,7 +23,6 @@ use tokio::task;
 extern crate log;
 use env_logger::Env;
 use libspdm::{responder, responder::CertModel, spdm};
-use nix::errno::Errno;
 use once_cell::sync::Lazy;
 
 pub static SOCKET_PATH: &str = "SPDM-Utils-loopback-socket";
@@ -35,6 +35,8 @@ mod io_buffers;
 mod nvme;
 mod qemu_server;
 mod request;
+#[cfg(feature = "scsi")]
+mod scsi;
 mod storage_standards;
 mod tcg_concise_evidence_binding;
 mod tcp_client;
@@ -49,19 +51,25 @@ const NVME_MSG: &str = "  - NVMe support (compile with --features nvme)\n";
 #[cfg(feature = "nvme")]
 const NVME_MSG: &str = "";
 
+#[cfg(not(feature = "scsi"))]
+const SCSI_MSG: &str = "  - SCSI support (compile with --features scsi)\n";
+#[cfg(feature = "scsi")]
+const SCSI_MSG: &str = "";
+
 #[cfg(not(feature = "pci"))]
 const PCI_MSG: &str = "  - PCI/DOE support (compile with --features pci)\n";
 #[cfg(feature = "pci")]
 const PCI_MSG: &str = "";
 
 const DISABLED_FEATURES: &str = formatcp!(
-    "{}{}{}",
-    if cfg!(all(feature = "nvme", feature = "pci")) {
+    "{}{}{}{}",
+    if cfg!(all(feature = "nvme", feature = "pci", feature = "scsi")) {
         ""
     } else {
         "DISABLED FEATURES:\n"
     },
     NVME_MSG,
+    SCSI_MSG,
     PCI_MSG
 );
 
@@ -87,8 +95,13 @@ struct Args {
     #[arg(long, default_value_t = 1)]
     nsid: u32,
 
-    /// Path to the block device
-    #[cfg(feature = "nvme")]
+    /// Use SCSI commands for the target device
+    #[cfg(feature = "scsi")]
+    #[arg(short, long, requires_ifs([("true", "blk_dev_path")]))]
+    scsi: bool,
+
+    /// Path to the block device (SCSI/NVMe)
+    #[cfg(any(feature = "nvme", feature = "scsi"))]
     #[arg(long)]
     blk_dev_path: Option<String>,
 
@@ -746,7 +759,10 @@ async fn main() -> Result<(), ()> {
     cli.nvme.then(|| {
         count += 1;
     });
-
+    #[cfg(feature = "scsi")]
+    cli.scsi.then(|| {
+        count += 1;
+    });
     #[cfg(feature = "pci")]
     cli.doe_pci_cfg.then(|| {
         count += 1;
@@ -777,6 +793,10 @@ async fn main() -> Result<(), ()> {
         }
         #[cfg(feature = "nvme")]
         if cli.nvme {
+            need_root = true;
+        }
+        #[cfg(feature = "scsi")]
+        if cli.scsi {
             need_root = true;
         }
 
@@ -810,7 +830,6 @@ async fn main() -> Result<(), ()> {
             error!("Only MCTP supported over USB I2C");
             return Err(());
         }
-
         usb_i2c::register_device(cntx_ptr, cli.usb_i2c_dev, cli.usb_i2c_baud)?;
     } else if cli.qemu_server {
         if let Commands::Request { .. } = cli.command {
@@ -864,7 +883,19 @@ async fn main() -> Result<(), ()> {
             nvme::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap(), cli.nsid).unwrap();
         }
 
-        #[cfg(not(any(feature = "nvme", feature = "pci")))]
+        #[cfg(feature = "scsi")]
+        if cli.scsi {
+            scsi::cmd_scsi_get_info(&cli.blk_dev_path.clone().unwrap()).unwrap();
+            if let Err(e) = scsi::cmd_scsi_get_sec_info(&cli.blk_dev_path.clone().unwrap()) {
+                if e == Errno::ENOTSUP {
+                    error!("SPDM is not supported by this device");
+                }
+                return Err(());
+            }
+            scsi::register_device(cntx_ptr, &cli.blk_dev_path.clone().unwrap())?;
+        }
+
+        #[cfg(not(any(feature = "nvme", feature = "pci", feature = "scsi")))]
         {
             error!("No supported backend specified");
             return Err(());
@@ -894,16 +925,24 @@ async fn main() -> Result<(), ()> {
                 )?;
             }
 
+            #[cfg(feature = "scsi")]
+            if cli.scsi {
+                trans_set = true;
+                spdm::setup_transport_layer(
+                    cntx_ptr,
+                    spdm::TransportLayer::Storage,
+                    spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
+                )?;
+            }
+
             #[cfg(feature = "pci")]
-            {
-                if cli.doe_pci_cfg {
-                    trans_set = true;
-                    spdm::setup_transport_layer(
-                        cntx_ptr,
-                        spdm::TransportLayer::Doe,
-                        spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
-                    )?;
-                }
+            if cli.doe_pci_cfg {
+                trans_set = true;
+                spdm::setup_transport_layer(
+                    cntx_ptr,
+                    spdm::TransportLayer::Doe,
+                    spdm::LIBSPDM_MAX_SPDM_MSG_SIZE,
+                )?;
             }
 
             // If we are QEMU response server, we could be here

--- a/src/scsi.rs
+++ b/src/scsi.rs
@@ -1,0 +1,829 @@
+// Licensed under the Apache License, Version 2.0 or the MIT License.
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+// Copyright (C) 2026, Western Digital Corporation or its affiliates.
+
+//! This file provides support for SPDM interfacing to a SCSI device
+//!
+//! SAFETY: This file includes a lot of unsafe Rust.
+//! If libspdm behaves in a manner we don't expect this will be very bad,
+//! so we are trusting libspdm here.
+//!
+use crate::*;
+use core::ffi::c_void;
+use core::ptr;
+use libspdm::spdm::LIBSPDM_MAX_SPDM_MSG_SIZE;
+use nix::errno::Errno;
+use nix::fcntl::{OFlag, open};
+use nix::libc::ioctl;
+use nix::sys::stat::{Mode, SFlag, stat};
+use nix::unistd::close;
+use std::slice::{from_raw_parts, from_raw_parts_mut};
+use std::sync::Mutex;
+
+const SEND_RECEIVE_BUFFER_LEN: usize = LIBSPDM_MAX_SPDM_MSG_SIZE as usize;
+// Global reference to the device instance to reduce sys-call overhead.
+// The execution context is already unsafe, what's the worst that could happen!
+static SCSI_DEV: Lazy<Mutex<Option<BlkDev>>> = Lazy::new(|| Mutex::new(None));
+
+const SG_SENSE_MAX_LENGTH: u8 = 64;
+const SG_BUF_MAX_SIZE: u32 = SEND_RECEIVE_BUFFER_LEN as u32;
+const SG_CDB_MAX_SIZE: u8 = 32;
+const SG_CDB_DEFAULT_SIZE: u8 = 16;
+const SG_CMD_TIMEOUT_MS: u32 = 30000;
+const SCSI_SEC_IN_OUT_CDB_LEN: usize = 12;
+
+// Sense Information
+const SG_SENSE_RESPONSE_CODE_MASK: u8 = 0x7F;
+
+// SPC6: Table 48
+const SG_SENSE_FIXED_CURRENT: u8 = 0x70;
+const SG_SENSE_FIXED_DEFERRED: u8 = 0x71;
+
+// SPC6: Table 28
+const SG_SENSE_DESCRIPTOR_CURRENT: u8 = 0x72;
+const SG_SENSE_DESCRIPTOR_DEFERRED: u8 = 0x73;
+
+// SPC6: Table 49 - Sense key descriptions
+const SG_SENSE_KEY_UNIT_ATTENTION: u8 = 0x6;
+
+// SPC6: Table 50 - ASC and ASCQ assignments
+const SG_SENSE_ASC_ASCQ_PWR_ON_RST: u16 = 0x2900;
+
+// Status codes.
+const _SG_CHECK_CONDITION: u8 = 0x02;
+
+// Host status codes.
+const SG_DID_OK: u16 = 0x00;
+const SG_DID_TIME_OUT: u16 = 0x03; // Timed out for other reason
+
+// Driver status codes.
+const SG_DRIVER_SENSE: u16 = 0x08;
+const SG_DRIVER_STATUS_MASK: u16 = 0x0f;
+
+// Device Flags
+const DEV_VENDOR_LEN: usize = 9;
+const DEV_ID_LEN: usize = 17;
+const DEV_REV_LEN: usize = 5;
+
+#[allow(dead_code)]
+struct SgCmd {
+    bufsz: u32,
+    io_hdr: sg_io_hdr_t,
+    sense_key: u8,
+    asc_ascq: u16,
+    cmdp: Vec<u8>,
+    dxferp: Vec<u8>,
+    sbp: Vec<u8>,
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct BlkDev {
+    fd: Option<i32>,
+    flags: OFlag,
+}
+
+impl BlkDev {
+    /// # Summary
+    ///
+    /// Create and return device structure to the SCSI device pointed to by
+    /// @path, where the underlying fd is opened with @flags.
+    ///
+    /// # Parameter
+    ///
+    /// * `path: path to the device
+    /// * `flags`: flags for the device to use on `open()`
+    ///
+    /// # Returns
+    ///
+    /// Err(Errno) on failure
+    /// Ok(BlkDev) on success, containing the file-descriptor for the device
+    fn new(path: &String, flags: OFlag) -> Result<BlkDev, Errno> {
+        let path = Path::new(path);
+        let st = stat(path);
+        info!("Getting device info for: {:?}", path);
+        if let Err(e) = st {
+            error!("Failed to get stat at {:?}: {}:?", path, e);
+            return Err(e);
+        }
+
+        let st = st.unwrap();
+        let st_mode = st.st_mode;
+
+        if ((SFlag::S_IFMT.bits() & st_mode) != SFlag::S_IFCHR.bits())
+            && ((SFlag::S_IFMT.bits() & st_mode) != SFlag::S_IFBLK.bits())
+        {
+            error!("Invalid device file {:?}", path);
+            return Err(Errno::EIO);
+        }
+
+        match open(path, flags, Mode::S_IRWXU) {
+            Ok(fd) => Ok(BlkDev {
+                fd: Some(fd),
+                flags,
+            }),
+            Err(e) => {
+                error!("Failed to open file {:?}: {:?}", path, e);
+                Err(e)
+            }
+        }
+    }
+}
+
+impl Drop for BlkDev {
+    /// # Summary
+    ///
+    /// Close the underlying file-descriptor when this instance goes out of scope
+    fn drop(&mut self) {
+        if let Some(fd) = self.fd {
+            close(fd).expect("failed to close device fd");
+            return;
+        }
+        unreachable!("device fd was not set!");
+    }
+}
+
+/// SCSI Primary Commands
+pub enum CmdType {
+    /// Inquire the device server for basic device information
+    Inquiry,
+    /// Requests the device server to return security protocol information
+    /// For SPDM: this is IF-RECV:
+    /// "Generic term for a security related command that transfers data
+    /// from the target to the initiator. For NVMe, this is Security
+    /// Receive. For SAS, this is SECURITY PROTOCOL IN. For SATA, this is
+    /// TRUSTED RECEIVE and TRUSTED RECEIVE DMA." -
+    /// https://github.com/DMTF/SPDM-WG/blob/master/docs/DSP0286/DSP0286.md#SPC-6
+    SecurityProtocolIn,
+    /// Requests the device server to process the specified parameter
+    /// list using the specified security protocol. For SPDM:
+    /// this is IF-SEND: "Generic term for a security related command that
+    /// transfers data from the initiator to the target.
+    /// For NVMe, this is Security Send. For SAS, this is
+    /// SECURITY PROTOCOL OUT. For SATA, this is TRUSTED SEND and
+    /// TRUSTED SEND DMA." -
+    /// https://github.com/DMTF/SPDM-WG/blob/master/docs/DSP0286/DSP0286.md#SPC-6
+    SecurityProtocolOut,
+}
+
+impl From<CmdType> for u8 {
+    fn from(c: CmdType) -> Self {
+        match c {
+            CmdType::Inquiry => 0x12,
+            CmdType::SecurityProtocolIn => 0xA2,
+            CmdType::SecurityProtocolOut => 0xB5,
+        }
+    }
+}
+
+/// Relevant Security Protocols per SCSI Primary Commands - 6 (SPC-6)
+#[derive(Debug, PartialEq)]
+pub enum SpcSecurityProtocols {
+    SecurityProtocolInformation,
+    DmtfSpdm,
+}
+
+impl From<SpcSecurityProtocols> for u8 {
+    fn from(c: SpcSecurityProtocols) -> Self {
+        match c {
+            SpcSecurityProtocols::SecurityProtocolInformation => 0x00,
+            SpcSecurityProtocols::DmtfSpdm => 0xE8,
+        }
+    }
+}
+
+impl TryFrom<u8> for SpcSecurityProtocols {
+    type Error = ();
+    fn try_from(v: u8) -> Result<Self, Self::Error> {
+        match v {
+            0x00 => Ok(SpcSecurityProtocols::SecurityProtocolInformation),
+            0xE8 => Ok(SpcSecurityProtocols::DmtfSpdm),
+            _ => Err(()),
+        }
+    }
+}
+
+impl SgCmd {
+    fn new(cdb_len: u8, direction: i32, bufsz: u32) -> Result<SgCmd, Errno> {
+        if bufsz > SG_BUF_MAX_SIZE {
+            return Err(Errno::EINVAL);
+        }
+        // Setup SGIO header. sg_io_hdr_t has no Default type but can be zero
+        // initialized and internal references set later.
+        let mut sg_io_hdr: sg_io_hdr_t = unsafe { std::mem::zeroed() };
+        // 'S' for SCSI generic/SG (required)
+        sg_io_hdr.interface_id = b'S' as i32;
+        sg_io_hdr.timeout = SG_CMD_TIMEOUT_MS;
+        sg_io_hdr.flags = SG_FLAG_DIRECT_IO;
+
+        if cdb_len != 0 {
+            if cdb_len > SG_CDB_MAX_SIZE {
+                return Err(Errno::E2BIG);
+            }
+            sg_io_hdr.cmd_len = cdb_len;
+        } else {
+            sg_io_hdr.cmd_len = SG_CDB_DEFAULT_SIZE;
+        }
+
+        sg_io_hdr.dxfer_direction = direction;
+        sg_io_hdr.dxfer_len = bufsz;
+        sg_io_hdr.mx_sb_len = SG_SENSE_MAX_LENGTH;
+
+        let mut sg_cmd = SgCmd {
+            bufsz,
+            io_hdr: sg_io_hdr,
+            sense_key: 0,
+            asc_ascq: 0,
+            // Must be heap allocated for FFI compatibility with C
+            // io_hdr.cmdp = cdb
+            cmdp: vec![0; SG_CDB_MAX_SIZE as usize],
+            // io_hdr.dxferp = buf
+            dxferp: vec![0; SG_BUF_MAX_SIZE as usize],
+            // io_hdr.sbp = sense_buf
+            sbp: vec![0; SG_SENSE_MAX_LENGTH as usize],
+        };
+
+        sg_cmd.set_io_buffer_ptrs();
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an Inquiry commands to retrieve basic information from the
+    /// device.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialized command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_dev_inquiry_info(cdb_len: u8, direction: i32, bufsz: u16) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz as u32)?;
+
+        // Setup Inquiry Command
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::Inquiry.into();
+        // Allocation Bytes
+        sg_cmd.cmdp[3..=4].copy_from_slice(&(bufsz.to_be_bytes()));
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an IF-SEND/SECURITY_IN command with the subcommand argument
+    /// specified to fetch the list of supported security protocols from the
+    /// device.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialized command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_security_protocols_list(
+        cdb_len: u8,
+        direction: i32,
+        bufsz: u32,
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+
+        // Setup Security In Command for protocol inquiry
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolIn.into();
+        // Security Protocol
+        sg_cmd.cmdp[1] = SpcSecurityProtocols::SecurityProtocolInformation.into();
+        // Security Protocol Specific
+        // This should be updated at the transport level, at this stage
+        // we don't know the message type/connection type.
+        sg_cmd.cmdp[2] = 0x00; // Operation - TBD (unknown at this stage)
+        sg_cmd.cmdp[3] = 0x00; // Reserved
+        sg_cmd.cmdp[4] = 0x00; // Not using increments of 512B in allocation length
+        // Allocation Length Bytes
+        sg_cmd.cmdp[6..=9].copy_from_slice(&((bufsz).to_be_bytes()));
+        sg_cmd.cmdp[11] = 0x00;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Use the transport header generated by `libspdm` to generate a SCSI
+    /// Security Protocol Out command.
+    ///
+    /// # Parameter
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `msg_length`: Message length
+    /// * `bufsz`: Data buffer size
+    /// * `header`: libspdm encoded spdm storage transport header
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialized command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_libspdm_request(
+        cdb_len: u8,
+        direction: i32,
+        msg_length: usize,
+        bufsz: u32,
+        header: &mut [u8; LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize],
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+        let hdr =
+            unsafe { *(header.as_mut_ptr() as *mut libspdm_storage_transport_virtual_header_t) };
+
+        // Setup Security Out Command for SPDM request [IF-SEND]
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolOut.into();
+        sg_cmd.cmdp[1] = hdr.security_protocol;
+        // All fields in the storage transport are little endian
+        let spsp = u16::from_le(hdr.security_protocol_specific);
+        sg_cmd.cmdp[2..=3].copy_from_slice(&spsp.to_be_bytes());
+        sg_cmd.cmdp[4] = 0;
+        sg_cmd.cmdp[5] = 0;
+
+        // Transfer Length
+        assert!(msg_length > LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize);
+        let transfer_len: u32 = (msg_length - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize)
+            .try_into()
+            .unwrap();
+        sg_cmd.cmdp[6..=9].copy_from_slice(&transfer_len.to_be_bytes());
+        sg_cmd.cmdp[10] = 0;
+        sg_cmd.cmdp[11] = 0;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Generate an IF-RECV/SECURITY_IN command to fetch an SPDM response.
+    /// This should be used when a response is expected from the target device.
+    ///
+    /// * `cdb_len`: Command data block length
+    /// * `direction`: SG IO direction
+    /// * `bufsz`: Data buffer size
+    /// * `message`: response buffer
+    /// * `message_size`: response buffer size
+    ///
+    /// # Returns
+    ///
+    /// Ok(SgCmd), An initialized command structure
+    /// Err(Errno), An error representing the cause of failure
+    fn gen_libspdm_response(
+        cdb_len: u8,
+        direction: i32,
+        bufsz: u32,
+        message: *mut u8,
+        message_size: usize,
+    ) -> Result<SgCmd, Errno> {
+        let mut sg_cmd = SgCmd::new(cdb_len, direction, bufsz)?;
+        let header_len = LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize;
+        let mut transport_message_len = message_size;
+        // We pass a pointer to this pointer when calling `libspdm_storage_encode_message()`
+        // and buf_ptr ends up being changed to point at a section of `reply` in libspdm.
+        let mut transport_message = ptr::null_mut();
+
+        unsafe {
+            libspdm_storage_encode_message(
+                ptr::null_mut(),
+                0,
+                message_size - header_len,
+                message as *mut _ as *mut c_void,
+                &mut transport_message_len,
+                &mut transport_message as *mut *mut c_void,
+            )
+        };
+
+        let transp_msg = unsafe { from_raw_parts_mut(transport_message, transport_message_len) };
+        let hdr = unsafe {
+            *(transp_msg.as_mut_ptr() as *mut libspdm_storage_transport_virtual_header_t)
+        };
+
+        // Setup Security In Command for SPDM response [IF-RECV]
+        // OpCode
+        sg_cmd.cmdp[0] = CmdType::SecurityProtocolIn.into();
+        sg_cmd.cmdp[1] = hdr.security_protocol;
+        // All fields in the storage transport are little endian
+        let spsp = u16::from_le(hdr.security_protocol_specific);
+        sg_cmd.cmdp[2..=3].copy_from_slice(&spsp.to_be_bytes());
+        sg_cmd.cmdp[4] = 0;
+        sg_cmd.cmdp[5] = 0;
+
+        // Allocation Length
+        assert!(message_size > LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize);
+        let allocation_len: u32 = (message_size - LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize)
+            .try_into()
+            .unwrap();
+        sg_cmd.cmdp[6..=9].copy_from_slice(&allocation_len.to_be_bytes());
+        sg_cmd.cmdp[10] = 0;
+        sg_cmd.cmdp[11] = 0;
+
+        Ok(sg_cmd)
+    }
+
+    /// # Summary
+    ///
+    /// Sets the buffer pointers in SgCmd.io_hdr to point to heap allocated
+    /// io buffers in SgCmd. These buffers must be heap allocated for FFI
+    /// compatibility with C. Behavior maybe undefined otherwise.
+    ///
+    /// # Returns
+    ///
+    /// Ok(()), on success
+    /// Err(()), if io_hdr is None
+    fn set_io_buffer_ptrs(&mut self) {
+        self.io_hdr.cmdp = self.cmdp.as_mut_ptr();
+        self.io_hdr.dxferp = self.dxferp.as_mut_ptr() as *mut c_void;
+        self.io_hdr.sbp = self.sbp.as_mut_ptr();
+    }
+
+    /// # Summary
+    ///
+    /// Execute a command to the device using `ioctl`. The command must be
+    /// setup/generated prior invoking this method.
+    ///
+    /// # Parameter
+    ///
+    /// * `fd: file-descriptor to the device, not that is must be opened
+    ///         with the correct flags for the command.
+    ///
+    /// # Returns
+    ///
+    /// Err(Errno), on failure
+    /// Ok(()), on success
+    fn scsi_cmd_exec(&mut self, fd: i32) -> Result<(), Errno> {
+        let rc = unsafe { ioctl(fd, SG_IO as u64, &mut self.io_hdr as *mut _ as *mut c_void) };
+        if rc != 0 {
+            let rc = Errno::last();
+            error!("SG_IO ioctl failed: {}", rc);
+            return Err(rc);
+        }
+
+        if self.io_hdr.status != 0
+            || self.io_hdr.host_status != SG_DID_OK
+            || ((self.io_hdr.driver_status & SG_DRIVER_STATUS_MASK != 0)
+                && (self.io_hdr.driver_status & SG_DRIVER_STATUS_MASK != SG_DRIVER_SENSE))
+        {
+            if self.io_hdr.host_status == SG_DID_TIME_OUT {
+                error!("SCSI command failed (timeout)");
+                return Err(Errno::ETIMEDOUT);
+            }
+
+            error!("SCSI command failed");
+            return Err(Errno::EIO);
+        }
+
+        if self.io_hdr.resid != 0 {
+            self.bufsz -= u32::try_from(self.io_hdr.resid)
+                .expect("unexpected overflow converting i32 to u32");
+        }
+        Ok(())
+    }
+
+    /// # Summary
+    ///
+    /// Given a fulfilled sense response from the device, log the Sense Key, ASC
+    /// and ASCQ and return the sense_key and asc_ascq concatenated.
+    ///
+    /// # Returns
+    ///
+    /// Some<(sense_key, asc_ascq)>, if valid
+    /// None, if not set
+    fn log_and_get_sense(&self) -> Option<(u8, u16)> {
+        /// Parse sense data and log it. Helper function to extract sense_key and asc_ascq
+        /// from the sense buffer at the specified offsets.
+        fn parse_and_log_sense(
+            sbp: &[u8],
+            sense_key_offset: usize,
+            asc_offset: usize,
+            ascq_offset: usize,
+        ) -> (u8, u16) {
+            let sense_key = sbp[sense_key_offset] & 0x0F;
+            let asc_ascq = ((sbp[asc_offset] as u16) << 8) | sbp[ascq_offset] as u16;
+            warn!("sense_key: 0x{sense_key:x?}");
+            warn!("asc_ascq: 0x{asc_ascq:x?}");
+            (sense_key, asc_ascq)
+        }
+
+        let response_code = self.sbp[0] & SG_SENSE_RESPONSE_CODE_MASK;
+        match response_code {
+            SG_SENSE_DESCRIPTOR_CURRENT | SG_SENSE_DESCRIPTOR_DEFERRED => {
+                Some(parse_and_log_sense(&self.sbp, 1, 2, 3))
+            }
+            SG_SENSE_FIXED_CURRENT | SG_SENSE_FIXED_DEFERRED => {
+                Some(parse_and_log_sense(&self.sbp, 2, 12, 13))
+            }
+            _ => {
+                debug!("No sense detected");
+                None
+            }
+        }
+    }
+}
+
+/// # Summary
+///
+/// Generate a command to request a list of supported security protocols by the
+/// device. We check for SPDM support.
+///
+/// # Parameter
+///
+/// * `path: path to the device
+///
+/// # Returns
+///
+/// Ok(()), on success
+/// Err(Errno), on any errors
+pub fn cmd_scsi_get_sec_info(path: &String) -> Result<(), Errno> {
+    // 1. Open device
+    let dev = BlkDev::new(path, OFlag::O_RDWR)?;
+    // The actual buffer has a fixed length much larger
+    let bufsz = 256;
+    // 2. Generate command
+    let mut cmd = SgCmd::gen_security_protocols_list(0, SG_DXFER_FROM_DEV, bufsz)?;
+    // 3. Execute CMD
+    if let Some(fd) = &dev.fd {
+        if let Err(e) = cmd.scsi_cmd_exec(*fd) {
+            if let Some((sense_key, asc_ascq)) = cmd.log_and_get_sense() {
+                if sense_key == SG_SENSE_KEY_UNIT_ATTENTION
+                    && asc_ascq == SG_SENSE_ASC_ASCQ_PWR_ON_RST
+                {
+                    // This is a Power ON/Reset/Bus Reset condition, maybe the drive
+                    // wasn't initialized. Retry the command, if it fails again,
+                    // let the caller handle it.
+                    warn!("Sense Condition: Power On/Reset detected");
+                    cmd.scsi_cmd_exec(*fd)?;
+                } else {
+                    return Err(Errno::ENXIO);
+                }
+            } else {
+                return Err(e);
+            }
+        }
+    } else {
+        return Err(Errno::ENXIO);
+    }
+
+    let sec_prot_list_len: u16 = u16::from_be_bytes(
+        cmd.dxferp[6..=7]
+            .try_into()
+            .expect("failed to split slice into constant size array"),
+    );
+
+    info!("--- Security Info List ---");
+    info!("  Length of Security Protocol List: {}", sec_prot_list_len);
+    // As per SFCR: Table 27 — Supported security protocols SECURITY PROTOCOL
+    // IN parameter data protocol list starts at offset 8...N, where N
+    // indicates the total length, in bytes, N = sec_prot_list_len
+    // bufsz - 8 => the remaining bytes in this header
+    assert!((sec_prot_list_len as u32) < bufsz - 8);
+    // If `SUPPORTED SECURITY PROTOCOL` is supported, this length shall be
+    // greater than 0.
+    assert!(sec_prot_list_len > 0);
+
+    if sec_prot_list_len <= 1 {
+        warn!("No security protocols supported by: {:?}", path);
+    }
+    let mut spdm_support = false;
+    for i in 0..sec_prot_list_len {
+        if let Ok(sec_prot) = SpcSecurityProtocols::try_from(cmd.dxferp[(8 + i) as usize]) {
+            info!("  {:?}  - Supported", sec_prot);
+            if sec_prot == SpcSecurityProtocols::DmtfSpdm {
+                spdm_support = true;
+            }
+        }
+    }
+    info!("--- End of Security Information List ---");
+
+    if !spdm_support {
+        // Device does not support SPDM
+        return Err(Errno::ENOTSUP);
+    }
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// Generate a command to get basic device information from the device pointed
+/// to by @path, then print the information returned.
+///
+/// # Parameter
+///
+/// * `path: path to the device
+///
+/// # Returns
+///
+/// Ok(()), on success
+/// Err(Errno), on any errors
+pub fn cmd_scsi_get_info(path: &String) -> Result<(), Errno> {
+    // 1. Open device
+    let dev = BlkDev::new(path, OFlag::O_RDONLY)?;
+    // 2. Generate command
+    let mut cmd = SgCmd::gen_dev_inquiry_info(0, SG_DXFER_FROM_DEV, 64)?;
+    // 3. Execute CMD
+    if let Some(fd) = &dev.fd {
+        cmd.scsi_cmd_exec(*fd).inspect_err(|e| {
+            error!("Failure to issue get info command: {e:?}");
+        })?;
+    } else {
+        return Err(Errno::ENXIO);
+    }
+
+    // 4. Display results
+    let vendor = String::from_utf8(cmd.dxferp[8..8 + (DEV_VENDOR_LEN - 1)].to_vec()).unwrap();
+    let id = String::from_utf8(cmd.dxferp[16..16 + (DEV_ID_LEN - 1)].to_vec()).unwrap();
+    let rev = String::from_utf8(cmd.dxferp[8..32 + (DEV_REV_LEN - 1)].to_vec()).unwrap();
+
+    info!("vendor: {vendor}");
+    info!("id: {id}");
+    info!("rev: {rev}");
+
+    Ok(())
+}
+
+/// # Summary
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Number of elements in `message_ptr` to send
+/// * `message_ptr`: A pointer to the data buffer to be sent
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn scsi_send_message(
+    _context: *mut c_void,
+    message_size: usize,
+    message_ptr: *const c_void,
+    _timeout: u64,
+) -> u32 {
+    info!("Sending SCSI SECURITY_OUT SPDM Command (request)");
+
+    match &mut *SCSI_DEV.lock().unwrap() {
+        // 1. Get device
+        Some(dev) => {
+            let message = message_ptr as *const u8;
+            let msg_buf = unsafe { from_raw_parts(message, message_size) };
+            // 2. Generate Request Header
+            let header_len = LIBSPDM_STORAGE_TRANSPORT_HEADER_SIZE as usize;
+            let mut cmd = SgCmd::gen_libspdm_request(
+                0,
+                SG_DXFER_TO_DEV,
+                message_size,
+                SG_BUF_MAX_SIZE,
+                &mut msg_buf[0..header_len].try_into().unwrap(),
+            )
+            .unwrap();
+
+            assert!(message_size < cmd.dxferp.capacity());
+            // Copy in SPDM buffer to the SG command IO buffer
+            cmd.dxferp[..(message_size - header_len)]
+                .copy_from_slice(&msg_buf[header_len..((message_size - header_len) + header_len)]);
+
+            // 3. Execute CMD
+            debug!(
+                "spdm-sending: IF_SEND: cmdp:   {:x?}",
+                &cmd.cmdp[0..SCSI_SEC_IN_OUT_CDB_LEN]
+            );
+            debug!(
+                "spdm-sending: dxferp: {:x?}",
+                &cmd.dxferp[0..(message_size - header_len)]
+            );
+
+            if let Some(fd) = &dev.fd {
+                cmd.scsi_cmd_exec(*fd)
+                    .expect("Failed to execute cmd, security in failed");
+            }
+        }
+        None => unreachable!("SCSI device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+///
+/// # Parameter
+///
+/// * `_context`: The SPDM context
+/// * `message_size`: Returns the number of bytes received in this transaction
+/// * `message_ptr`: A pointer to a data buffer of a minimum size of
+///                 `SEND_RECEIVE_BUFFER_LEN` to capture the received bytes.
+/// * `_timeout`: Transaction timeout (Unsupported)
+///
+/// # Returns
+///
+/// (0) on success
+///
+/// # Panics
+///
+/// Panics if the buffers passed in are invalid or for any other point of
+/// failure.
+#[unsafe(no_mangle)]
+unsafe extern "C" fn scsi_receive_message(
+    _context: *mut c_void,
+    message_size: *mut usize,
+    message_ptr: *mut *mut c_void,
+    _timeout: u64,
+) -> u32 {
+    match &mut *SCSI_DEV.lock().unwrap() {
+        // 1. Get device
+        Some(dev) => {
+            let message = unsafe { *message_ptr as *mut u8 };
+            let msg_buf = unsafe { from_raw_parts_mut(message, SEND_RECEIVE_BUFFER_LEN) };
+
+            info!("Sending SCSI SECURITY_IN SPDM Command (receive response)");
+            // 2. Generate Response Header
+            let mut cmd = SgCmd::gen_libspdm_response(
+                0,
+                SG_DXFER_FROM_DEV,
+                SG_BUF_MAX_SIZE,
+                message,
+                unsafe { *message_size },
+            )
+            .unwrap();
+
+            // 3. Execute CMD
+            debug!(
+                "spdm-sending: IF_RECV: cmdp:   {:x?}",
+                &cmd.cmdp[0..SCSI_SEC_IN_OUT_CDB_LEN]
+            );
+
+            if let Some(fd) = &dev.fd {
+                cmd.scsi_cmd_exec(*fd)
+                    .expect("Failed to execute cmd, security in failed");
+            }
+
+            // 4. Copy in the received buffer
+            assert!(cmd.bufsz > 0);
+            assert!(msg_buf.len() >= cmd.bufsz as usize);
+            assert!(cmd.dxferp.len() >= cmd.bufsz as usize);
+
+            msg_buf[..(cmd.bufsz as usize)].copy_from_slice(&cmd.dxferp[..(cmd.bufsz as usize)]);
+
+            // Allow libspdm to do top-bottom SPDM message parsing, we don't know the
+            // number of valid bytes in the reception buffer.
+            unsafe { *message_size = LIBSPDM_MAX_SPDM_MSG_SIZE as usize };
+
+            info!("received_bytes: {:?}", unsafe { *message_size });
+            info!("spdm-received: {:x?}", unsafe {
+                &msg_buf[0..*message_size]
+            });
+        }
+        None => unreachable!("SCSI device lost"),
+    }
+    0
+}
+
+/// # Summary
+///
+///
+/// # Parameter
+///
+/// * `context`: The SPDM context
+///
+/// # Returns
+///
+/// Ok(()) on success
+///
+/// # Panics
+///
+/// Panics if `SEND_BUFFER/RECEIVE_BUFFER` is occupied
+pub fn register_device(context: *mut c_void, dev_path: &String) -> Result<(), ()> {
+    unsafe {
+        *SCSI_DEV.lock().unwrap() = Some(BlkDev::new(dev_path, OFlag::O_RDWR).unwrap());
+        libspdm_register_device_io_func(
+            context,
+            Some(scsi_send_message),
+            Some(scsi_receive_message),
+        );
+        io_buffers::libspdm_setup_io_buffers(
+            context,
+            SEND_RECEIVE_BUFFER_LEN,
+            SEND_RECEIVE_BUFFER_LEN,
+        )?;
+    }
+
+    Ok(())
+}

--- a/wrapper.h
+++ b/wrapper.h
@@ -9,6 +9,10 @@
 #ifdef NVME
 #include <libnvme.h>
 #endif // NVME
+#ifdef SCSI
+#include <scsi/scsi.h>
+#include <scsi/sg.h>
+#endif //SCSI
 #endif // RUST_STD
 
 #include <library/spdm_common_lib.h>


### PR DESCRIPTION
Implement SCSI/ATA transport layer for SPDM communication with SCSI/ATA devices per DSP0286 specification. Adds Linux SCSI Generic (SG) interface support using SECURITY PROTOCOL IN/OUT commands.

With that:
- Implement SCSI command builders (Inquiry, Security Protocol In/Out)
- Support device capability detection and sense data parsing
- Add 'scsi' feature flag to conditionally compile SCSI support
- Add conditional compile option --scsi to selectively compile this transport

The implementation uses Linux SCSI Generic (sg) driver via ioctl for low-level device communication and handles some SCSI sense conditions including power-on/reset retry logic.